### PR TITLE
Strange error when logging out

### DIFF
--- a/src/appsdeck/session/destroy.go
+++ b/src/appsdeck/session/destroy.go
@@ -6,5 +6,8 @@ import (
 )
 
 func DestroyToken() error {
+	if _, err := os.Stat(constants.AuthConfigFile); os.IsNotExist(err) {
+		return nil
+	}
 	return os.Remove(constants.AuthConfigFile)
 }


### PR DESCRIPTION
```
yannski@laptop:~/Bureau/workspace/contestapp$ APPSDECK_API=https://staging.appsdeck.eu appsdeck logout
panic: remove /home/yannski/.config/appsdeck/auth: no such file or directory

goroutine 1 [running]:
runtime.panic(0x696840, 0xc2100774e0)
    /opt/go-1.2/src/pkg/runtime/panic.c:266 +0xb6
appsdeck/cmd.func·004(0xc21006dc40)
    /home/leo/Appsdeck/appsdeck/src/appsdeck/cmd/logout.go:16 +0x53
github.com/codegangsta/cli.Command.Run(0x712420, 0x6, 0x0, 0x0, 0x73bf30, ...)
    /home/leo/Appsdeck/appsdeck/src/github.com/codegangsta/cli/command.go:73 +0x994
github.com/codegangsta/cli.(*App).Run(0xc2100ad160, 0xc21000a000, 0x2, 0x2, 0x3, ...)
    /home/leo/Appsdeck/appsdeck/src/github.com/codegangsta/cli/app.go:111 +0x855
main.main()
    /home/leo/Appsdeck/appsdeck/src/appsdeck/main.go:29 +0x2c1

goroutine 3 [runnable]:
os/signal.loop()
    /opt/go-1.2/src/pkg/os/signal/signal_unix.go:19
created by os/signal.init·1
    /opt/go-1.2/src/pkg/os/signal/signal_unix.go:27 +0x31
```
