### PR TITLE
Clarify error when connection on appsdeck-run port is blocked by proxy or

### DIFF
--- a/src/appsdeck/apps/run.go
+++ b/src/appsdeck/apps/run.go
@@ -142,6 +142,16 @@ func connectToRunServer(rawUrl string) (*http.Response, net.Conn, error) {
 
 	res, err := conn.Do(req)
 	if err != httputil.ErrPersistEOF && err != nil {
+		if err, ok := err.(*net.OpError); ok {
+			if err.Err.Error() == "record overflow" {
+				return nil, nil, fmt.Errorf(
+					"Fail to create a secure connection to Appsdeck server\n"+
+						"The encountered error is: %v (ID: CLI-1001)\n"+
+						"Your firewall or proxy may block the connection to %s",
+					err, url.Host,
+				)
+			}
+		}
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
firewall

Fixes #32 
