### PR TITLE
Multiplatform helper to build ssh tunnels

### DIFF
--- a/cmd/db-tunnel.go
+++ b/cmd/db-tunnel.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/Scalingo/cli/appdetect"
+	"github.com/Scalingo/cli/db"
+	"github.com/codegangsta/cli"
+)
+
+var (
+	DbTunnelCommand = cli.Command{
+		Name:  "db-tunnel",
+		Usage: "Create an encrypted connection to access your database",
+		Flags: []cli.Flag{
+			cli.StringFlag{Name: "identity, i", Usage: "SSH Private Key", Value: os.Getenv("HOME") + "/.ssh/id_rsa", EnvVar: ""},
+			cli.IntFlag{Name: "port, p", Usage: "Local port to bind", Value: 0, EnvVar: ""},
+		},
+		Description: `Create an SSH-encrypted connection to access your database locally
+	Example
+	  'scalingo --app my-app db-tunnel APPSDECK_MONGO_URL'`,
+		Action: func(c *cli.Context) {
+			currentApp := appdetect.CurrentApp(c.GlobalString("app"))
+			if len(c.Args()) != 1 {
+				cli.ShowCommandHelp(c, "ps")
+			} else if err := db.Tunnel(currentApp, c.Args()[0], c.String("identity"), c.Int("port")); err != nil {
+				errorQuit(err)
+			}
+		},
+	}
+)

--- a/config/config.go
+++ b/config/config.go
@@ -14,7 +14,8 @@ import (
 type Config struct {
 	ApiUrl       string
 	ApiPrefix    string
-	UnsecureUrl  bool
+	SshHost      string
+	UnsecureSsl  bool
 	RollbarToken string
 	ConfigDir    string
 	AuthFile     string
@@ -24,6 +25,7 @@ type Config struct {
 var (
 	env = map[string]string{
 		"API_URL":       "https://scalingo-api-production.appsdeck.eu",
+		"SSH_HOST":      "appsdeck.eu:22",
 		"API_PREFIX":    "/v1",
 		"UNSECURE_SSL":  "false",
 		"ROLLBAR_TOKEN": "",
@@ -63,7 +65,7 @@ func init() {
 	rollbar.ErrorWriter = logFile
 
 	TlsConfig = &tls.Config{}
-	if C.UnsecureUrl {
+	if C.UnsecureSsl {
 		TlsConfig.InsecureSkipVerify = true
 		TlsConfig.MinVersion = tls.VersionTLS10
 	} else {

--- a/db/tunnel.go
+++ b/db/tunnel.go
@@ -1,0 +1,139 @@
+package db
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/url"
+	"sync"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/Scalingo/cli/api"
+	"github.com/Scalingo/cli/config"
+	"gopkg.in/errgo.v1"
+)
+
+var (
+	connIDGenerator = make(chan int)
+)
+
+func Tunnel(app string, dbEnvVar string, identity string, port int) error {
+	environ, err := api.VariablesList(app)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+
+	dbUrlStr := dbEnvVarValue(dbEnvVar, environ)
+	if dbUrlStr == "" {
+		return errgo.Newf("no such environment variable: %s", dbEnvVar)
+	}
+
+	dbUrl, err := url.Parse(dbUrlStr)
+	if err != nil {
+		return errgo.Notef(err, "invalid database 'URL': %s", dbUrlStr)
+	}
+	fmt.Printf("Building tunnel to %s\n", dbUrl.Host)
+
+	privateKey, err := sshPrivateKey(identity)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+
+	sshConfig := &ssh.ClientConfig{
+		User: "git",
+		Auth: []ssh.AuthMethod{ssh.PublicKeys(privateKey)},
+	}
+
+	client, err := ssh.Dial("tcp", config.C.SshHost, sshConfig)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+
+	tcpAddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("localhost:%d", port))
+	if err != nil {
+		return errgo.Mask(err)
+	}
+
+	sock, err := net.ListenTCP("tcp", tcpAddr)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	defer sock.Close()
+	fmt.Printf("You can access your database on '%v'\n", sock.Addr())
+
+	go startIDGenerator()
+	errs := make(chan error)
+	for {
+		select {
+		case err := <-errs:
+			return errgo.Mask(err)
+		default:
+		}
+
+		connToTunnel, err := sock.Accept()
+		if err != nil {
+			return errgo.Mask(err)
+		}
+		go handleConnToTunnel(client, dbUrl, connToTunnel, errs)
+	}
+
+	return nil
+}
+
+func dbEnvVarValue(dbEnvVar string, environ api.Variables) string {
+	for _, env := range environ {
+		if env.Name == dbEnvVar {
+			return env.Value
+		}
+	}
+	return ""
+}
+
+func sshPrivateKey(path string) (ssh.Signer, error) {
+	privateKey, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+
+	privateKeySigner, err := ssh.ParsePrivateKey(privateKey)
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+
+	return privateKeySigner, nil
+}
+
+func handleConnToTunnel(sshClient *ssh.Client, dbUrl *url.URL, sock net.Conn, errs chan error) {
+	connID := <-connIDGenerator
+	fmt.Printf("Connect to %s [%v]\n", dbUrl.Host, connID)
+	conn, err := sshClient.Dial("tcp", dbUrl.Host)
+	if err != nil {
+		errs <- err
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		io.Copy(sock, conn)
+		sock.Close()
+		wg.Done()
+	}()
+
+	go func() {
+		io.Copy(conn, sock)
+		conn.Close()
+		wg.Done()
+	}()
+
+	wg.Wait()
+
+	fmt.Printf("End of connection [%d]\n", connID)
+}
+
+func startIDGenerator() {
+	for i := 1; ; i++ {
+		connIDGenerator <- i
+	}
+}

--- a/scalingo/main.go
+++ b/scalingo/main.go
@@ -46,6 +46,9 @@ func main() {
 		cmd.AddonPlansCommand,
 		cmd.AddonResourcesListCommand,
 
+		// DB Access
+		cmd.DbTunnelCommand,
+
 		// SSH keys
 		cmd.ListSSHKeyCommand,
 		cmd.AddSSHKeyCommand,


### PR DESCRIPTION
Helper to avoid this: `ssh -L 3001:db-6771.mongo.dbs.staging.appsdeck.eu:30007 git@staging.appsdeck.eu -N`

Usage: `scalingo -a myapp db-tunnel DATABASE_URL`
