### PR TITLE
Fix #137 : collaborators-add completion now uses goroutines

### DIFF
--- a/cmd/autocomplete/collaborators_add.go
+++ b/cmd/autocomplete/collaborators_add.go
@@ -54,6 +54,7 @@ func CollaboratorsAddAutoComplete(c *cli.Context) error {
 		}
 	}()
 	wg.Wait()
+	close(ch)
 
 	for email, _ := range setEmails {
 		isAlreadyCollaborator := false

--- a/cmd/autocomplete/collaborators_add.go
+++ b/cmd/autocomplete/collaborators_add.go
@@ -32,6 +32,7 @@ func CollaboratorsAddAutoComplete(c *cli.Context) error {
 	setEmails := make(map[string]bool)
 	for _, app := range apps {
 		go func(app *api.App, setEmails map[string]bool) {
+			defer wg.Done()
 			appCollaborators, erro := api.CollaboratorsList(app.Name)
 			if erro != nil {
 				err = erro
@@ -40,7 +41,6 @@ func CollaboratorsAddAutoComplete(c *cli.Context) error {
 			for _, col := range appCollaborators {
 				setEmails[col.Email] = true
 			}
-			wg.Done()
 		}(app, setEmails)
 	}
 	wg.Wait()


### PR DESCRIPTION
When you are completing by doing `<tab><tab>`, `collaborators-add` can have a lot of requests to do depending on you apps' number.