### PR TITLE
Fix #151: Destroy command is always run

### DIFF
--- a/apps/destroy.go
+++ b/apps/destroy.go
@@ -11,7 +11,7 @@ import (
 func Destroy(appName string) error {
 	var validationName string
 
-	res, err := scalingo.AppsShow(appName)
+	_, err := scalingo.AppsShow(appName)
 	if err != nil {
 		return errgo.Mask(err, errgo.Any)
 	}
@@ -22,7 +22,7 @@ func Destroy(appName string) error {
 		return errgo.Newf("'%s' is not '%s', aborting…\n", validationName, appName)
 	}
 
-	res, err = scalingo.AppsDestroy(appName, validationName)
+	res, err := scalingo.AppsDestroy(appName, validationName)
 	if err != nil {
 		return errgo.Notef(err, "fail to destroy app")
 	}

--- a/apps/destroy.go
+++ b/apps/destroy.go
@@ -10,13 +10,19 @@ import (
 
 func Destroy(appName string) error {
 	var validationName string
+
+	res, err := scalingo.AppsShow(appName)
+	if err != nil {
+		return errgo.Mask(err, errgo.Any)
+	}
+
 	fmt.Printf("/!\\ You're going to delete %s, this operation is irreversible.\nTo confirm type the name of the application: ", appName)
 	fmt.Scan(&validationName)
 	if validationName != appName {
 		return errgo.Newf("'%s' is not '%s', aborting…\n", validationName, appName)
 	}
 
-	res, err := scalingo.AppsDestroy(appName, validationName)
+	res, err = scalingo.AppsDestroy(appName, validationName)
 	if err != nil {
 		return errgo.Notef(err, "fail to destroy app")
 	}


### PR DESCRIPTION
`scalingo destroy` was always run, whatever appname you gave.
I thought it would be better to check if the app is existing or not first.

So two requests instead of one, but the user has to type its app name again to confirm.
If he has to confirm an app that doesn't exists, it's even more bad than a 100ms request.