### PR TITLE
Command suggestions

### DIFF
--- a/cmd/suggestions.go
+++ b/cmd/suggestions.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Scalingo/cli/Godeps/_workspace/src/github.com/Scalingo/codegangsta-cli"
+)
+
+func ShowSuggestions(c *cli.Context) {
+	var suggestions []string
+	cmdName := c.Args().First()
+
+	startRange := 3
+	if 3 >= len(cmdName) {
+		startRange = len(cmdName) % 4
+	}
+	endRange := len(cmdName) - startRange
+
+	if startRange >= 0 {
+		for _, cmd := range c.App.Commands {
+			if strings.HasPrefix(cmd.Name, cmdName[:startRange]) {
+				suggestions = append(suggestions, cmd.Name)
+			} else if strings.HasSuffix(cmd.Name, cmdName[endRange:]) {
+				suggestions = append(suggestions, cmd.Name)
+			}
+		}
+	}
+
+	if len(c.Args()) > 1 {
+		alikeCmd := ""
+		matches := 0
+		tmpMatches := 0
+		for _, cmd := range c.App.Commands {
+			for _, a := range c.Args() {
+				for _, f := range cmd.Flags {
+					for _, s := range strings.Split(f.String(), ", ") {
+						if s == a {
+							tmpMatches += 1
+						}
+					}
+				}
+			}
+			if tmpMatches > matches {
+				alikeCmd = cmd.Name
+				matches = tmpMatches
+			}
+			tmpMatches = 0
+		}
+
+		if alikeCmd != "" {
+			fullCmd := "scalingo " + alikeCmd + " " + strings.Join(c.Args()[1:], " ")
+			suggestions = append(suggestions, fullCmd)
+		}
+	}
+
+	if len(suggestions) > 0 {
+		fmt.Println("You might be looking for:")
+		for _, s := range suggestions {
+			fmt.Printf("  - '%s'\n", s)
+		}
+	}
+}

--- a/cmd/suggestions.go
+++ b/cmd/suggestions.go
@@ -11,9 +11,9 @@ func ShowSuggestions(c *cli.Context) {
 	var suggestions []string
 	cmdName := c.Args().First()
 
-	startRange := 3
-	if 3 >= len(cmdName) {
-		startRange = len(cmdName) % 4
+	startRange := 2
+	if 2 >= len(cmdName) {
+		startRange = len(cmdName) % 3
 	}
 	endRange := len(cmdName) - startRange
 
@@ -24,33 +24,6 @@ func ShowSuggestions(c *cli.Context) {
 			} else if strings.HasSuffix(cmd.Name, cmdName[endRange:]) {
 				suggestions = append(suggestions, cmd.Name)
 			}
-		}
-	}
-
-	if len(c.Args()) > 1 {
-		alikeCmd := ""
-		matches := 0
-		tmpMatches := 0
-		for _, cmd := range c.App.Commands {
-			for _, a := range c.Args() {
-				for _, f := range cmd.Flags {
-					for _, s := range strings.Split(f.String(), ", ") {
-						if s == a {
-							tmpMatches += 1
-						}
-					}
-				}
-			}
-			if tmpMatches > matches {
-				alikeCmd = cmd.Name
-				matches = tmpMatches
-			}
-			tmpMatches = 0
-		}
-
-		if alikeCmd != "" {
-			fullCmd := "scalingo " + alikeCmd + " " + strings.Join(c.Args()[1:], " ")
-			suggestions = append(suggestions, fullCmd)
 		}
 	}
 

--- a/scalingo/main.go
+++ b/scalingo/main.go
@@ -26,6 +26,7 @@ func DefaultAction(c *cli.Context) {
 
 	if !completeMode {
 		cmd.HelpCommand.Action(c)
+		cmd.ShowSuggestions(c)
 	} else {
 		i := len(os.Args) - 2
 		if i > 0 {


### PR DESCRIPTION
https://github.com/Scalingo/cli/issues/157
Suggest commands if the user has done a typo, it works by showing commands that match the two first/last characters of his command, i.e:

```
scalingo cops
No help topic for 'cops'
You might be looking for:
  - 'apps'
  - 'ps'
  - 'collaborators'
  - 'collaborators-add'
  - 'collaborators-remove'
```

The following commands match `co.*` or `.*ps`:

* ap**ps**
* **ps**
* **co**llaborators
* **co**llaborators-add
* **co**llaborators-remove