### PR TITLE
Fix #166 and revert to Scanln(&login) for dpl comp

### DIFF
--- a/cmd/suggestions.go
+++ b/cmd/suggestions.go
@@ -27,7 +27,7 @@ func ShowSuggestions(c *cli.Context) {
 		}
 	}
 
-	if len(suggestions) > 0 {
+	if len(c.Args()) > 0 && len(suggestions) > 0 {
 		fmt.Println("You might be looking for:")
 		for _, s := range suggestions {
 			fmt.Printf("  - '%s'\n", s)

--- a/config/auth.go
+++ b/config/auth.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -114,7 +113,7 @@ func tryAuth() (*users.User, error) {
 
 	for login == "" {
 		fmt.Print("Username or email: ")
-		login, err = bufio.NewReader(os.Stdin).ReadString('\n')
+		_, err := fmt.Scanln(&login)
 		if err != nil {
 			if strings.Contains(err.Error(), "unexpected newline") {
 				continue


### PR DESCRIPTION
- Fixed suggestions showing the whole list of commands when passing no arguments
- Previous method `bufio.NewReader().ReadString("\n")` wasn't compatible with dpl