### PR TITLE
Add `scalingo deploy` to deploy an archive

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -22,19 +22,19 @@
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo",
-			"Rev": "1100a82b8fbbadef4a2c93796141fadbd22a13c3"
+			"Rev": "f1587fb99d8e9c38c0f5b8491d4666819fc80003"
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo/billing",
-			"Rev": "1100a82b8fbbadef4a2c93796141fadbd22a13c3"
+			"Rev": "f1587fb99d8e9c38c0f5b8491d4666819fc80003"
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo/debug",
-			"Rev": "1100a82b8fbbadef4a2c93796141fadbd22a13c3"
+			"Rev": "f1587fb99d8e9c38c0f5b8491d4666819fc80003"
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo/io",
-			"Rev": "1100a82b8fbbadef4a2c93796141fadbd22a13c3"
+			"Rev": "f1587fb99d8e9c38c0f5b8491d4666819fc80003"
 		},
 		{
 			"ImportPath": "github.com/Soulou/errgo-rollbar",

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ COMMANDS:
     deployments		List app deployments
     deployment-logs	View deployment logs
     deployment-follow	Follow deployment event stream
-    push  Trigger a deployment by archive
+    deploy		Trigger a deployment by archive
 
   Display metrics of the running containers:
     stats	Display metrics of the currently running containers

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Once that's done, all you have to do is to 'go get' the project, with the follow
 go get github.com/Scalingo/cli/scalingo
 ```
 
-That it, you've build the latest version of the Scalingo CLI (the binary will be present in `$GOPATH/bin/scalingo`)
+That's it, you've build the latest version of the Scalingo CLI (the binary will be present in `$GOPATH/bin/scalingo`)
 
 
 ## How to upgrade?
@@ -93,7 +93,8 @@ COMMANDS:
   Deployment:
     deployments		List app deployments
     deployment-logs	View deployment logs
-    deployment-follow	Follow deployement event stream
+    deployment-follow	Follow deployment event stream
+    push  Trigger a deployment by archive
 
   Display metrics of the running containers:
     stats	Display metrics of the currently running containers

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -35,10 +35,11 @@ var (
 		DomainsRemoveCommand,
 		DomainsSSLCommand,
 
-		// Deploiments
+		// Deployments
 		DeploymentsListCommand,
 		DeploymentLogCommand,
 		DeploymentFollowCommand,
+		DeploymentPushCommand,
 
 		// Collaborators
 		CollaboratorsListCommand,

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -39,7 +39,7 @@ var (
 		DeploymentsListCommand,
 		DeploymentLogCommand,
 		DeploymentFollowCommand,
-		DeploymentPushCommand,
+		DeploymentDeployCommand,
 
 		// Collaborators
 		CollaboratorsListCommand,

--- a/cmd/deployments.go
+++ b/cmd/deployments.go
@@ -68,8 +68,8 @@ var (
 			}
 		},
 	}
-	DeploymentPushCommand = cli.Command{
-		Name:     "push",
+	DeploymentDeployCommand = cli.Command{
+		Name:     "deploy",
 		Category: "Deployment",
 		Usage:    "Trigger a deployment by archive",
 		Flags:    []cli.Flag{appFlag},
@@ -93,7 +93,7 @@ var (
 				gitRef = args[1]
 			}
 			currentApp := appdetect.CurrentApp(c)
-			err := deployments.Push(currentApp, archivePath, gitRef)
+			err := deployments.Deploy(currentApp, archivePath, gitRef)
 			if err != nil {
 				errorQuit(err)
 			}

--- a/cmd/deployments.go
+++ b/cmd/deployments.go
@@ -74,9 +74,9 @@ var (
 		Usage:    "Trigger a deployment by archive",
 		Flags:    []cli.Flag{appFlag},
 		Description: ` Trigger the deployment of a custom archive for your application
-		$ scalingo -a myapp push archive.tar.gz
+		$ scalingo -a myapp deploy archive.tar.gz
 		or
-		$ scalingo -a myapp push http://example.com/archive.tar.gz
+		$ scalingo -a myapp deploy http://example.com/archive.tar.gz
 
     # See also commands 'deployments'
 `,
@@ -84,7 +84,7 @@ var (
 		Action: func(c *cli.Context) {
 			args := c.Args()
 			if len(args) != 1 && len(args) != 2 {
-				cli.ShowCommandHelp(c, "push")
+				cli.ShowCommandHelp(c, "deploy")
 				return
 			}
 			archivePath := args[0]
@@ -99,7 +99,7 @@ var (
 			}
 		},
 		BashComplete: func(c *cli.Context) {
-			autocomplete.CmdFlagsAutoComplete(c, "push")
+			autocomplete.CmdFlagsAutoComplete(c, "deploy")
 		},
 	}
 )

--- a/cmd/deployments.go
+++ b/cmd/deployments.go
@@ -52,18 +52,54 @@ var (
 	DeploymentFollowCommand = cli.Command{
 		Name:     "deployment-follow",
 		Category: "Deployment",
-		Usage:    "Follow deployement event stream",
+		Usage:    "Follow deployment event stream",
 		Flags:    []cli.Flag{appFlag},
 		Description: ` Get real-time deployment informations
 		$ scalingo -a myapp deployment-follow
-		`,
+`,
 		Before: AuthenticateHook,
 		Action: func(c *cli.Context) {
 			currentApp := appdetect.CurrentApp(c)
-			err := deployments.Stream(currentApp)
+			err := deployments.Stream(&deployments.StreamOpts{
+				AppName: currentApp,
+			})
 			if err != nil {
 				errorQuit(err)
 			}
+		},
+	}
+	DeploymentPushCommand = cli.Command{
+		Name:     "push",
+		Category: "Deployment",
+		Usage:    "Trigger a deployment by archive",
+		Flags:    []cli.Flag{appFlag},
+		Description: ` Trigger the deployment of a custom archive for your application
+		$ scalingo -a myapp push archive.tar.gz
+		or
+		$ scalingo -a myapp push http://example.com/archive.tar.gz
+
+    # See also commands 'deployments'
+`,
+		Before: AuthenticateHook,
+		Action: func(c *cli.Context) {
+			args := c.Args()
+			if len(args) != 1 && len(args) != 2 {
+				cli.ShowCommandHelp(c, "push")
+				return
+			}
+			archivePath := args[0]
+			gitRef := ""
+			if len(args) == 2 {
+				gitRef = args[1]
+			}
+			currentApp := appdetect.CurrentApp(c)
+			err := deployments.Push(currentApp, archivePath, gitRef)
+			if err != nil {
+				errorQuit(err)
+			}
+		},
+		BashComplete: func(c *cli.Context) {
+			autocomplete.CmdFlagsAutoComplete(c, "push")
 		},
 	}
 )

--- a/deployments/deploy.go
+++ b/deployments/deploy.go
@@ -13,11 +13,11 @@ import (
 	"gopkg.in/errgo.v1"
 )
 
-type PushRes struct {
+type DeployRes struct {
 	Deployment *scalingo.Deployment `json:"deployment"`
 }
 
-func Push(app, archivePath, gitRef string) error {
+func Deploy(app, archivePath, gitRef string) error {
 	_, err := url.Parse(archivePath)
 	if err != nil {
 		// TODO differentiate local file and URL
@@ -49,7 +49,7 @@ func Push(app, archivePath, gitRef string) error {
 		return errgo.Mask(err, errgo.Any)
 	}
 
-	pushRes := &PushRes{}
+	pushRes := &DeployRes{}
 	if err = json.Unmarshal(body, &pushRes); err != nil {
 		return errgo.Mask(err, errgo.Any)
 	}

--- a/deployments/deploy.go
+++ b/deployments/deploy.go
@@ -49,13 +49,13 @@ func Deploy(app, archivePath, gitRef string) error {
 		return errgo.Mask(err, errgo.Any)
 	}
 
-	pushRes := &DeployRes{}
-	if err = json.Unmarshal(body, &pushRes); err != nil {
+	deployRes := &DeployRes{}
+	if err = json.Unmarshal(body, &deployRes); err != nil {
 		return errgo.Mask(err, errgo.Any)
 	}
 	err = Stream(&StreamOpts{
 		AppName:      app,
-		DeploymentID: pushRes.Deployment.ID,
+		DeploymentID: deployRes.Deployment.ID,
 	})
 	if err != nil {
 		return errgo.Mask(err, errgo.Any)

--- a/deployments/follow.go
+++ b/deployments/follow.go
@@ -37,7 +37,6 @@ type statusData struct {
 // deployments.
 // The StreamOpts.DeploymentID argument is optional.
 func Stream(opts *StreamOpts) error {
-	// TODO Sometimes, the logs of the previous deployments show up at the begining...
 	c := config.ScalingoClient()
 	app, err := c.AppsShow(opts.AppName)
 	if err != nil {

--- a/deployments/follow.go
+++ b/deployments/follow.go
@@ -100,7 +100,7 @@ func Stream(opts *StreamOpts) error {
 					fmt.Println("[STATUS] New status: " + oldStatus + " →  " + statusData.Content)
 				}
 				oldStatus = statusData.Content
-				if scalingo.IsFinishedString(statusData.Content) {
+				if opts.DeploymentID != "" && scalingo.IsFinishedString(statusData.Content) {
 					return nil
 				}
 			case "new":

--- a/deployments/logs.go
+++ b/deployments/logs.go
@@ -4,12 +4,12 @@ import (
 	stdio "io"
 	"os"
 
-	"gopkg.in/errgo.v1"
 	"github.com/Scalingo/cli/config"
 	"github.com/Scalingo/cli/io"
+	"gopkg.in/errgo.v1"
 )
 
-func Logs(app string, deployment string) error {
+func Logs(app, deployment string) error {
 	client := config.ScalingoClient()
 	deploy, err := client.Deployment(app, deployment)
 

--- a/deployments/push.go
+++ b/deployments/push.go
@@ -1,0 +1,65 @@
+package deployments
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/url"
+	"strings"
+
+	"github.com/Scalingo/cli/config"
+	"github.com/Scalingo/go-scalingo"
+	"github.com/Scalingo/go-scalingo/io"
+
+	"gopkg.in/errgo.v1"
+)
+
+type PushRes struct {
+	Deployment *scalingo.Deployment `json:"deployment"`
+}
+
+func Push(app, archivePath, gitRef string) error {
+	_, err := url.Parse(archivePath)
+	if err != nil {
+		// TODO differentiate local file and URL
+		// For instance if error 400 is returned, it means that archivePath is not an URL (so maybe a
+		// local file?)
+		return errgo.Mask(err, errgo.Any)
+	}
+
+	io.Status("Downloading the source code")
+	c := config.ScalingoClient()
+	params := &scalingo.DeploymentArchiveParams{
+		SourceURL: archivePath,
+	}
+	// TODO gitRef cannot be anything. It is used in the docker tag image. For example, it cannot
+	// start with a dash
+	if strings.TrimSpace(gitRef) != "" {
+		params.GitRef = &gitRef
+	}
+	res, err := c.DeploymentArchive(app, params)
+	if err != nil {
+		return errgo.Mask(err, errgo.Any)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 201 {
+		return errgo.Newf("fail to deploy the archive: %s", res.Status)
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return errgo.Mask(err, errgo.Any)
+	}
+
+	pushRes := &PushRes{}
+	if err = json.Unmarshal(body, &pushRes); err != nil {
+		return errgo.Mask(err, errgo.Any)
+	}
+	err = Stream(&StreamOpts{
+		AppName:      app,
+		DeploymentID: pushRes.Deployment.ID,
+	})
+	if err != nil {
+		return errgo.Mask(err, errgo.Any)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Waiting for Scalingo/go-scalingo#13 to be merged before merging this one.

```
╰─$ scalingo -a clitest deploy https://github.com/Scalingo/sample-ruby-sinatra/archive/master.tar.gz
-----> Downloading the source code
[NEW] New deploy: bfd30404-6855-4980-b4f8-2986b97d7881 from etiennem
[LOG] -----> Buildpack version 1.3.0
[LOG] -----> Compiling Ruby/Rack
[LOG] -----> Using Ruby version: ruby-2.3.3
[LOG] -----> Installing dependencies using 1.9.7
[LOG] Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
[LOG] Fetching gem metadata from https://rubygems.org/..........
[LOG] Fetching version metadata from https://rubygems.org/..
[LOG] Using bundler 1.9.7
[LOG] Installing tilt 1.4.1
[LOG] Installing rack 1.5.2
[LOG] Installing rack-protection 1.5.0
[LOG] Installing sinatra 1.4.3
[LOG] Bundle complete! 1 Gemfile dependency, 5 gems now installed.
[LOG] Gems in the groups development and test were not installed.
[LOG] Bundled gems are installed into ./vendor/bundle.
[LOG] Bundle completed (4.64s)
[LOG] Cleaning up the bundler cache.
[LOG] -----> Procfile declares types -> web
[LOG] 
[LOG] -----> Build complete, uploading deployment cache.
[STATUS] New status: pushing
[LOG]  Build complete, shipping your container...
[STATUS] New status: pushing →  starting
[LOG]  Waiting for your application to boot... 
[LOG] <-- https://clitest.scalingo.io -->
[STATUS] New status: starting →  success
╰─$ 
```


Fix #275 