### PR TITLE
Add deploy war option

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/Scalingo/cli",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v74",
+	"GodepVersion": "v79",
 	"Packages": [
 		"./..."
 	],
@@ -22,19 +22,19 @@
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo",
-			"Rev": "65158f84d41e0f0a94b3b3ad350cdff8c18f3299"
+			"Rev": "01baffaac33133ba0116b7edcdb5aae286567554"
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo/billing",
-			"Rev": "65158f84d41e0f0a94b3b3ad350cdff8c18f3299"
+			"Rev": "01baffaac33133ba0116b7edcdb5aae286567554"
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo/debug",
-			"Rev": "65158f84d41e0f0a94b3b3ad350cdff8c18f3299"
+			"Rev": "01baffaac33133ba0116b7edcdb5aae286567554"
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo/io",
-			"Rev": "65158f84d41e0f0a94b3b3ad350cdff8c18f3299"
+			"Rev": "01baffaac33133ba0116b7edcdb5aae286567554"
 		},
 		{
 			"ImportPath": "github.com/Soulou/errgo-rollbar",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -22,19 +22,19 @@
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo",
-			"Rev": "f1587fb99d8e9c38c0f5b8491d4666819fc80003"
+			"Rev": "ce38d682a4dbca795524384923c3666b515ff742"
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo/billing",
-			"Rev": "f1587fb99d8e9c38c0f5b8491d4666819fc80003"
+			"Rev": "ce38d682a4dbca795524384923c3666b515ff742"
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo/debug",
-			"Rev": "f1587fb99d8e9c38c0f5b8491d4666819fc80003"
+			"Rev": "ce38d682a4dbca795524384923c3666b515ff742"
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo/io",
-			"Rev": "f1587fb99d8e9c38c0f5b8491d4666819fc80003"
+			"Rev": "ce38d682a4dbca795524384923c3666b515ff742"
 		},
 		{
 			"ImportPath": "github.com/Soulou/errgo-rollbar",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -22,19 +22,19 @@
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo",
-			"Rev": "ce38d682a4dbca795524384923c3666b515ff742"
+			"Rev": "65158f84d41e0f0a94b3b3ad350cdff8c18f3299"
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo/billing",
-			"Rev": "ce38d682a4dbca795524384923c3666b515ff742"
+			"Rev": "65158f84d41e0f0a94b3b3ad350cdff8c18f3299"
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo/debug",
-			"Rev": "ce38d682a4dbca795524384923c3666b515ff742"
+			"Rev": "65158f84d41e0f0a94b3b3ad350cdff8c18f3299"
 		},
 		{
 			"ImportPath": "github.com/Scalingo/go-scalingo/io",
-			"Rev": "ce38d682a4dbca795524384923c3666b515ff742"
+			"Rev": "65158f84d41e0f0a94b3b3ad350cdff8c18f3299"
 		},
 		{
 			"ImportPath": "github.com/Soulou/errgo-rollbar",

--- a/cmd/deployments.go
+++ b/cmd/deployments.go
@@ -5,6 +5,7 @@ import (
 	"github.com/Scalingo/cli/cmd/autocomplete"
 	"github.com/Scalingo/cli/deployments"
 	"github.com/Scalingo/codegangsta-cli"
+	"github.com/Scalingo/go-scalingo/io"
 )
 
 var (
@@ -72,7 +73,9 @@ var (
 		Name:     "deploy",
 		Category: "Deployment",
 		Usage:    "Trigger a deployment by archive",
-		Flags:    []cli.Flag{appFlag},
+		Flags: []cli.Flag{appFlag,
+			cli.BoolFlag{Name: "war, w", Usage: "Specify that you want to deploy a WAR file"},
+		},
 		Description: ` Trigger the deployment of a custom archive for your application
 		$ scalingo -a myapp deploy archive.tar.gz
 		or
@@ -93,9 +96,18 @@ var (
 				gitRef = args[1]
 			}
 			currentApp := appdetect.CurrentApp(c)
-			err := deployments.Deploy(currentApp, archivePath, gitRef)
-			if err != nil {
-				errorQuit(err)
+			if c.Bool("war") {
+				io.Status("Deploy a WAR archive")
+				err := deployments.DeployWar(currentApp, archivePath, gitRef)
+				if err != nil {
+					errorQuit(err)
+				}
+			} else {
+				io.Status("Deploy an archive")
+				err := deployments.Deploy(currentApp, archivePath, gitRef)
+				if err != nil {
+					errorQuit(err)
+				}
 			}
 		},
 		BashComplete: func(c *cli.Context) {

--- a/cmd/deployments.go
+++ b/cmd/deployments.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/Scalingo/cli/appdetect"
 	"github.com/Scalingo/cli/cmd/autocomplete"
 	"github.com/Scalingo/cli/deployments"
@@ -96,14 +99,14 @@ var (
 				gitRef = args[1]
 			}
 			currentApp := appdetect.CurrentApp(c)
-			if c.Bool("war") {
-				io.Status("Deploy a WAR archive")
+			if c.Bool("war") || strings.HasSuffix(archivePath, ".war") {
+				io.Status(fmt.Sprintf("Deploying WAR archive: %s", archivePath))
 				err := deployments.DeployWar(currentApp, archivePath, gitRef)
 				if err != nil {
 					errorQuit(err)
 				}
 			} else {
-				io.Status("Deploy an archive")
+				io.Status(fmt.Sprintf("Deploying tarball archive: %s", archivePath))
 				err := deployments.Deploy(currentApp, archivePath, gitRef)
 				if err != nil {
 					errorQuit(err)

--- a/deployments/deploy.go
+++ b/deployments/deploy.go
@@ -3,7 +3,6 @@ package deployments
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"mime"
 	"net/http"
@@ -44,12 +43,10 @@ func Deploy(app, archivePath, gitRef string) error {
 	if strings.TrimSpace(gitRef) != "" {
 		params.GitRef = &gitRef
 	}
-	fmt.Println("DeploymentArchive")
 	res, err := c.DeploymentArchive(app, params)
 	if err != nil {
 		return errgo.Mask(err, errgo.Any)
 	}
-	fmt.Println("Deployment accepted")
 	defer res.Body.Close()
 	if res.StatusCode != 201 {
 		return errgo.Newf("fail to deploy the archive: %s", res.Status)
@@ -63,7 +60,6 @@ func Deploy(app, archivePath, gitRef string) error {
 	if err = json.Unmarshal(body, &deployRes); err != nil {
 		return errgo.Mask(err, errgo.Any)
 	}
-	fmt.Println("stream")
 	err = Stream(&StreamOpts{
 		AppName:      app,
 		DeploymentID: deployRes.Deployment.ID,

--- a/deployments/deploy.go
+++ b/deployments/deploy.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/Scalingo/cli/config"
 	"github.com/Scalingo/go-scalingo"
-	"github.com/Scalingo/go-scalingo/io"
 
 	"gopkg.in/errgo.v1"
 )
@@ -26,7 +25,6 @@ func Deploy(app, archivePath, gitRef string) error {
 		return errgo.Mask(err, errgo.Any)
 	}
 
-	io.Status("Downloading the source code")
 	c := config.ScalingoClient()
 	params := &scalingo.DeploymentArchiveParams{
 		SourceURL: archivePath,

--- a/deployments/deploy_war.go
+++ b/deployments/deploy_war.go
@@ -107,6 +107,9 @@ func DeployWar(appName, warPath, gitRef string) error {
 		//close(tarErrorChannel)
 	}()
 	archiveBytes, err := ioutil.ReadAll(pipeReader)
+	if err != nil {
+		return errgo.Mask(err, errgo.Any)
+	}
 	tarError := <-tarErrorChannel
 	if tarError != nil {
 		fmt.Println("error in tar")

--- a/deployments/deploy_war.go
+++ b/deployments/deploy_war.go
@@ -2,12 +2,10 @@ package deployments
 
 import (
 	"archive/tar"
-	"bytes"
 	"compress/gzip"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"mime"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -18,7 +16,6 @@ import (
 	"github.com/Scalingo/cli/config"
 
 	"github.com/Scalingo/go-scalingo"
-	scalingoio "github.com/Scalingo/go-scalingo/io"
 
 	errgo "gopkg.in/errgo.v1"
 )
@@ -123,20 +120,7 @@ func DeployWar(appName, warPath, gitRef string) error {
 		return errgo.Mask(err, errgo.Any)
 	}*/
 
-	scalingoio.Status("Uploading archive to Scalingo...")
-	req, err := http.NewRequest("PUT", sources.UploadURL, bytes.NewReader(archiveBytes))
-	if err != nil {
-		return errgo.Mask(err, errgo.Any)
-	}
-
-	req.Header.Set("Date", time.Now().UTC().Format(http.TimeFormat))
-	req.Header.Add("Content-Type", mime.TypeByExtension(".gz"))
-	req.ContentLength = int64(len(archiveBytes))
-
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return errgo.Mask(err, errgo.Any)
-	}
+	res, err := uploadArchiveBytes(sources.UploadURL, archiveBytes)
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		return errgo.Newf("wrong status code after upload %s", res.Status)

--- a/deployments/deploy_war.go
+++ b/deployments/deploy_war.go
@@ -159,15 +159,3 @@ func getFileInfo(warPath string) (warReadStream io.ReadCloser, warSize int64, wa
 	}
 	return
 }
-
-func _devTGzipArchive(tarWriter *tar.Writer, warReadStream io.ReadCloser, header *tar.Header) error {
-	err := tarWriter.WriteHeader(header)
-	if err != nil {
-		return errgo.Mask(err, errgo.Any)
-	}
-	_, err = io.Copy(tarWriter, warReadStream)
-	if err != nil {
-		return errgo.Mask(err, errgo.Any)
-	}
-	return nil
-}

--- a/deployments/deploy_war.go
+++ b/deployments/deploy_war.go
@@ -44,7 +44,7 @@ func DeployWar(appName, warPath, gitRef string) error {
 		if err != nil {
 			return errgo.Mask(err, errgo.Any)
 		}
-		warFileName = appName
+		warFileName = appName + ".war"
 	} else {
 		fmt.Println("If is file, just archive in tgz")
 		warReadStream, warSize, warFileName, err = getFileInfo(warPath)
@@ -55,7 +55,7 @@ func DeployWar(appName, warPath, gitRef string) error {
 	defer warReadStream.Close()
 	// Create the tar header
 	header := &tar.Header{
-		Name:       fmt.Sprintf("%s/%s.war", appName, warFileName),
+		Name:       fmt.Sprintf("%s/%s", appName, warFileName),
 		Typeflag:   tar.TypeReg, // Is a regular file
 		Mode:       0644,
 		ModTime:    time.Now(),

--- a/deployments/deploy_war.go
+++ b/deployments/deploy_war.go
@@ -132,7 +132,7 @@ func DeployWar(appName, warPath, gitRef string) error {
 
 	fmt.Printf("Archive downloadable at %s\n", sources.DownloadURL)
 
-	return nil
+	return Deploy(appName, sources.DownloadURL, gitRef)
 }
 
 func getURLInfo(warPath string) (warReadStream io.ReadCloser, warSize int64, err error) {

--- a/deployments/deploy_war.go
+++ b/deployments/deploy_war.go
@@ -1,0 +1,140 @@
+package deployments
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Scalingo/go-scalingo"
+
+	errgo "gopkg.in/errgo.v1"
+)
+
+type DeployWarRes struct {
+	Deployment *scalingo.Deployment `json:"deployment"`
+}
+
+func DeployWar(appName, warPath, gitRef string) error {
+	// TODO algo
+	// 1. If file
+	// 1.b. if url, download the archive and go to 2
+	// 2. insert into a tgz (inside a folder)
+	// 3. send it to the new /source endpoint
+	// 4. Use the signed URL from 3. to deploy the code
+
+	// TODO out should be the /sources endpoint
+	out, err := os.Create(appName + ".tgz")
+	if err != nil {
+		return errgo.Mask(err, errgo.Any)
+	}
+	defer out.Close()
+
+	var warReadStream io.ReadCloser
+	var warSize int64
+	var warFileName string
+	if strings.HasPrefix(warPath, "http://") || strings.HasPrefix(warPath, "https://") {
+		fmt.Println("If is URL, download the WAR")
+		warReadStream, warSize, err = getURLInfo(warPath)
+		if err != nil {
+			return errgo.Mask(err, errgo.Any)
+		}
+		warFileName = appName
+	} else {
+		fmt.Println("If is file, just archive in tgz")
+		warReadStream, warSize, warFileName, err = getFileInfo(warPath)
+		if err != nil {
+			return errgo.Mask(err, errgo.Any)
+		}
+	}
+	defer warReadStream.Close()
+
+	gzWriter := gzip.NewWriter(out)
+	defer gzWriter.Close()
+	tarWriter := tar.NewWriter(gzWriter)
+	defer tarWriter.Close()
+
+	header := &tar.Header{
+		Name:       fmt.Sprintf("%s/%s.war", appName, warFileName),
+		Typeflag:   tar.TypeReg, // Is a regular file
+		Mode:       0644,
+		ModTime:    time.Now(),
+		AccessTime: time.Now(),
+		ChangeTime: time.Now(),
+	}
+	if warSize != 0 {
+		// TODO It is mandatory. What to do if we cannot find the size
+		header.Size = warSize
+	}
+	_ = warSize
+	err = tarWriter.WriteHeader(header)
+	if err != nil {
+		return errgo.Mask(err, errgo.Any)
+	}
+
+	n, err := io.Copy(tarWriter, warReadStream)
+	if err != nil {
+		return errgo.Mask(err, errgo.Any)
+	}
+	fmt.Printf("copied bytes: %d\n", n)
+
+	/*b, err := ioutil.ReadAll(warReadStream)
+	if err != nil {
+		return errgo.Mask(err, errgo.Any)
+	}
+	_, err = tarWriter.Write(b)
+	if err != nil {
+		return errgo.Mask(err, errgo.Any)
+	}*/
+
+	/*c := config.ScalingoClient()
+	_ = c
+
+	err = Stream(&StreamOpts{
+		AppName: appName,
+		//DeploymentID: deployRes.Deployment.ID,
+	})
+	if err != nil {
+		return errgo.Mask(err, errgo.Any)
+	}*/
+
+	return nil
+}
+
+func getURLInfo(warPath string) (warReadStream io.ReadCloser, warSize int64, err error) {
+	res, err := http.Get(warPath)
+	if err != nil {
+		err = errgo.Mask(err, errgo.Any)
+		return
+	}
+	warReadStream = res.Body
+	if res.Header.Get("Content-Length") != "" {
+		i, err := strconv.ParseInt(res.Header.Get("Content-Length"), 10, 64)
+		if err == nil {
+			// If there is an error, we just skip this header
+			warSize = i
+		}
+	}
+	return
+}
+
+func getFileInfo(warPath string) (warReadStream io.ReadCloser, warSize int64, warFileName string, err error) {
+	warFileName = filepath.Base(warPath)
+	fi, err := os.Stat(warPath)
+	if err == nil {
+		// If there is an error, we just skip this header
+		warSize = fi.Size()
+	}
+	warReadStream, err = os.Open(warPath)
+	if err != nil {
+		err = errgo.Mask(err, errgo.Any)
+		return
+	}
+	return
+}

--- a/deployments/deploy_war.go
+++ b/deployments/deploy_war.go
@@ -37,14 +37,12 @@ func DeployWar(appName, warPath, gitRef string) error {
 	var warFileName string
 	var err error
 	if strings.HasPrefix(warPath, "http://") || strings.HasPrefix(warPath, "https://") {
-		fmt.Println("If is URL, download the WAR")
 		warReadStream, warSize, err = getURLInfo(warPath)
 		if err != nil {
 			return errgo.Mask(err, errgo.Any)
 		}
 		warFileName = appName + ".war"
 	} else {
-		fmt.Println("If is file, just archive in tgz")
 		warReadStream, warSize, warFileName, err = getFileInfo(warPath)
 		if err != nil {
 			return errgo.Mask(err, errgo.Any)
@@ -73,7 +71,6 @@ func DeployWar(appName, warPath, gitRef string) error {
 	if err != nil {
 		return errgo.Mask(err, errgo.Any)
 	}
-	fmt.Printf("Upload archive to %s\n", sources.UploadURL)
 
 	// The tar writer will write to the pipe. At the other end of the pipe we have the sources URL to
 	// upload to Scalingo.

--- a/vendor/github.com/Scalingo/go-scalingo/apps.go
+++ b/vendor/github.com/Scalingo/go-scalingo/apps.go
@@ -50,12 +50,6 @@ type AppLinks struct {
 	DeploymentsStream string `json:"deployments_stream"`
 }
 
-type AppDomains struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	SSL  bool   `json:"ssl"`
-}
-
 type App struct {
 	Id    string `json:"id"`
 	Name  string `json:"name"`
@@ -65,13 +59,12 @@ type App struct {
 		Email    string `json:"email"`
 		Billable bool   `json:"billable"`
 	} `json:"owner"`
-	GitUrl         string        `json:"git_url"`
-	LastDeployedAt *time.Time    `json:"last_deployed_at"`
-	LastDeployedBy string        `json:"last_deployed_by"`
-	CreatedAt      *time.Time    `json:"created_at"`
-	UpdatedAt      *time.Time    `json:"update_at"`
-	Links          *AppLinks     `json:"links"`
-	Domains        []*AppDomains `json:"domains"`
+	GitUrl         string     `json:"git_url"`
+	LastDeployedAt *time.Time `json:"last_deployed_at"`
+	LastDeployedBy string     `json:"last_deployed_by"`
+	CreatedAt      *time.Time `json:"created_at"`
+	UpdatedAt      *time.Time `json:"update_at"`
+	Links          *AppLinks  `json:"links"`
 }
 
 func (app App) String() string {

--- a/vendor/github.com/Scalingo/go-scalingo/client.go
+++ b/vendor/github.com/Scalingo/go-scalingo/client.go
@@ -3,6 +3,7 @@ package scalingo
 import (
 	"crypto/tls"
 	"net/http"
+	"time"
 )
 
 type HTTPClient interface {
@@ -18,12 +19,16 @@ type Client struct {
 }
 
 type ClientConfig struct {
+	Timeout   time.Duration
 	Endpoint  string
 	APIToken  string
 	TLSConfig *tls.Config
 }
 
 func NewClient(cfg ClientConfig) *Client {
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 30 * time.Second
+	}
 	if cfg.Endpoint == "" {
 		cfg.Endpoint = defaultEndpoint
 	}
@@ -36,6 +41,7 @@ func NewClient(cfg ClientConfig) *Client {
 		APIVersion: defaultAPIVersion,
 		TLSConfig:  cfg.TLSConfig,
 		httpClient: &http.Client{
+			Timeout: cfg.Timeout,
 			Transport: &http.Transport{
 				Proxy:           http.ProxyFromEnvironment,
 				TLSClientConfig: cfg.TLSConfig,

--- a/vendor/github.com/Scalingo/go-scalingo/sources.go
+++ b/vendor/github.com/Scalingo/go-scalingo/sources.go
@@ -1,0 +1,30 @@
+package scalingo
+
+import "gopkg.in/errgo.v1"
+
+type Source struct {
+	DownloadURL string `json:"download_url"`
+	UploadURL   string `json:"upload_url"`
+}
+
+func (c *Client) SourcesCreate() (*Source, error) {
+	req := &APIRequest{
+		Client:   c,
+		Method:   "POST",
+		Endpoint: "/sources",
+		Expected: Statuses{201},
+	}
+	res, err := req.Do()
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+	defer res.Body.Close()
+
+	var source *Source
+	err = ParseJSON(res, &source)
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+
+	return source, nil
+}

--- a/vendor/github.com/Scalingo/go-scalingo/sources.go
+++ b/vendor/github.com/Scalingo/go-scalingo/sources.go
@@ -2,6 +2,10 @@ package scalingo
 
 import "gopkg.in/errgo.v1"
 
+type SourcesCreateResponse struct {
+	Source *Source `json:"source"`
+}
+
 type Source struct {
 	DownloadURL string `json:"download_url"`
 	UploadURL   string `json:"upload_url"`
@@ -20,11 +24,11 @@ func (c *Client) SourcesCreate() (*Source, error) {
 	}
 	defer res.Body.Close()
 
-	var source *Source
-	err = ParseJSON(res, &source)
+	var sourceRes *SourcesCreateResponse
+	err = ParseJSON(res, &sourceRes)
 	if err != nil {
 		return nil, errgo.Mask(err)
 	}
 
-	return source, nil
+	return sourceRes.Source, nil
 }


### PR DESCRIPTION
Fix #278 

Not yet ready to be merged.

I have an error when reaching the API deployment endpoint. We make a HEAD request to the given URL in order to get the `Content-Type` and the `Content-Length` header (https://github.com/Scalingo/api/blob/master/app/controllers/app/deployments_controller.rb#L263).

But S3 returns a 403 response. I tried adding the `s3:HeadObject` right to the dev user but it does not change anything. Any idea on how to solve this one?

By the way, the error is not very nice for the end user as it is a 500 error on the API side so the CLI displays:

```
 !     An error occured:
       server internal error - our team has been notified
```

I am wondering how to bubble up nicely the error to the CLI.