### PR TITLE
Display Let's Encrypt certificate status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### To be Released
 
 * [alerts] Add support for the duration_before_trigger attribute [#407](https://github.com/Scalingo/cli/pull/407)
+* [domains] Handle Let's Encrypt certificate status [#410](https://github.com/Scalingo/cli/pull/410)
 
 ### 1.10.1
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,7 +18,7 @@
   revision = "97b505dac0c3696d7395d6627494ec105a69280f"
 
 [[projects]]
-  digest = "1:1e188cb6e7bf0df1b07b5c30248dc8043fc551c3a8de54d776c9c79644cbb878"
+  digest = "1:e637e5a503044d89bbc3580f2a708c35622ca6e4c62d8e0446661706a9b2ea62"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -29,8 +29,8 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "d02971611e1f5170b783c32f35807fae796450d1"
-  version = "v2.1.0"
+  revision = "bcbfda60303be06600207a9b6e6e95f2ae774348"
+  version = "v2.1.1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,7 +18,6 @@
   revision = "97b505dac0c3696d7395d6627494ec105a69280f"
 
 [[projects]]
-  branch = "master"
   digest = "1:1e188cb6e7bf0df1b07b5c30248dc8043fc551c3a8de54d776c9c79644cbb878"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
@@ -30,12 +29,8 @@
     "io",
   ]
   pruneopts = "NUT"
-<<<<<<< HEAD
   revision = "d02971611e1f5170b783c32f35807fae796450d1"
   version = "v2.1.0"
-=======
-  revision = "b2df3db622c7130c7d7fa8f4d3dec62a6ad2f15f"
->>>>>>> origin/master
 
 [[projects]]
   branch = "master"

--- a/domains/list.go
+++ b/domains/list.go
@@ -38,16 +38,14 @@ func List(app string) error {
 		row := []string{domainName}
 		if !domain.SSL {
 			row = append(row, "-")
-		} else {
-			var tls string
-			if domain.LetsEncrypt {
-				letsencryptStatus, ok := letsencryptStatusString[string(domain.LetsEncryptStatus)]
-				if !ok {
-					letsencryptStatus = string(domain.LetsEncryptStatus)
-				}
-				tls = fmt.Sprintf("(LE %s)", letsencryptStatus)
+		} else if domain.LetsEncrypt {
+			letsencryptStatus, ok := letsencryptStatusString[string(domain.LetsEncryptStatus)]
+			if !ok {
+				letsencryptStatus = string(domain.LetsEncryptStatus)
 			}
-			row = append(row, fmt.Sprintf("%s Valid until %v", tls, domain.Validity))
+			row = append(row, fmt.Sprintf("Let's Encrypt: %s", letsencryptStatus))
+		} else {
+			row = append(row, fmt.Sprintf("Valid until %v", domain.Validity))
 		}
 		t.Append(row)
 	}

--- a/domains/list.go
+++ b/domains/list.go
@@ -5,9 +5,18 @@ import (
 	"os"
 
 	"github.com/Scalingo/cli/config"
+	scalingo "github.com/Scalingo/go-scalingo"
 	"github.com/olekukonko/tablewriter"
 	"gopkg.in/errgo.v1"
 )
+
+var letsencryptStatusString = map[string]string{
+	string(scalingo.LetsEncryptStatusPendingDNS):  "Pending DNS",
+	string(scalingo.LetsEncryptStatusNew):         "Creating",
+	string(scalingo.LetsEncryptStatusCreated):     "In use",
+	string(scalingo.LetsEncryptStatusDNSRequired): "DNS required",
+	string(scalingo.LetsEncryptStatusError):       "Error",
+}
 
 func List(app string) error {
 	c := config.ScalingoClient()
@@ -17,7 +26,7 @@ func List(app string) error {
 	}
 
 	t := tablewriter.NewWriter(os.Stdout)
-	t.SetHeader([]string{"Domain", "SSL"})
+	t.SetHeader([]string{"Domain", "TLS/SSL"})
 	hasCanonical := false
 
 	for _, domain := range domains {
@@ -30,7 +39,15 @@ func List(app string) error {
 		if !domain.SSL {
 			row = append(row, "-")
 		} else {
-			row = append(row, fmt.Sprintf("Valid until %v", domain.Validity))
+			var tls string
+			if domain.LetsEncrypt {
+				letsencryptStatus, ok := letsencryptStatusString[string(domain.LetsEncryptStatus)]
+				if !ok {
+					letsencryptStatus = string(domain.LetsEncryptStatus)
+				}
+				tls = fmt.Sprintf("(LE %s)", letsencryptStatus)
+			}
+			row = append(row, fmt.Sprintf("%s Valid until %v", tls, domain.Validity))
 		}
 		t.Append(row)
 	}

--- a/vendor/github.com/Scalingo/go-scalingo/client.go
+++ b/vendor/github.com/Scalingo/go-scalingo/client.go
@@ -55,6 +55,10 @@ type ClientConfig struct {
 	AuthEndpoint        string
 	DatabaseAPIEndpoint string
 	APIToken            string
+
+	// StaticTokenGenerator is present for retrocompatibility with legacy tokens
+	// DEPRECATED, Use standard APIToken field for normal operations
+	StaticTokenGenerator *StaticTokenGenerator
 }
 
 func NewClient(cfg ClientConfig) *Client {
@@ -68,7 +72,11 @@ func (c *Client) ScalingoAPI() http.Client {
 	if c.apiClient != nil {
 		return c.apiClient
 	}
+
 	var tokenGenerator http.TokenGenerator
+	if c.config.StaticTokenGenerator != nil {
+		tokenGenerator = c.config.StaticTokenGenerator
+	}
 	if len(c.config.APIToken) != 0 {
 		tokenGenerator = http.NewAPITokenGenerator(c, c.config.APIToken)
 	}

--- a/vendor/github.com/Scalingo/go-scalingo/domains.go
+++ b/vendor/github.com/Scalingo/go-scalingo/domains.go
@@ -19,15 +19,35 @@ type DomainsService interface {
 
 var _ DomainsService = (*Client)(nil)
 
+type LetsEncryptStatus string
+
+const (
+	LetsEncryptStatusPendingDNS  LetsEncryptStatus = "pending_dns"
+	LetsEncryptStatusNew         LetsEncryptStatus = "new"
+	LetsEncryptStatusCreated     LetsEncryptStatus = "created"
+	LetsEncryptStatusDNSRequired LetsEncryptStatus = "dns_required"
+	LetsEncryptStatusError       LetsEncryptStatus = "error"
+)
+
+type ACMEErrorVariables struct {
+	DNSProvider string   `json:"dns_provider"`
+	Variables   []string `json:"variables"`
+}
+
 type Domain struct {
-	ID        string    `json:"id"`
-	AppID     string    `json:"app_id"`
-	Name      string    `json:"name"`
-	TLSCert   string    `json:"tlscert,omitempty"`
-	TLSKey    string    `json:"tlskey,omitempty"`
-	SSL       bool      `json:"ssl"`
-	Validity  time.Time `json:"validity"`
-	Canonical bool      `json:"canonical"`
+	ID                string             `json:"id"`
+	AppID             string             `json:"app_id"`
+	Name              string             `json:"name"`
+	TLSCert           string             `json:"tlscert,omitempty"`
+	TLSKey            string             `json:"tlskey,omitempty"`
+	SSL               bool               `json:"ssl"`
+	Validity          time.Time          `json:"validity"`
+	Canonical         bool               `json:"canonical"`
+	LetsEncrypt       bool               `json:"letsencrypt"`
+	LetsEncryptStatus LetsEncryptStatus  `json:"letsencrypt_status"`
+	AcmeDNSFqdn       string             `json:"acme_dns_fqdn"`
+	AcmeDNSValue      string             `json:"acme_dns_value"`
+	AcmeDNSError      ACMEErrorVariables `json:"acme_dns_error"`
 }
 
 type DomainsRes struct {


### PR DESCRIPTION
Fix #409

```
$ go build -o cli ./scalingo && ./cli -a my-app domains
+----------------+--------------------------------+
|     DOMAIN     |            TLS/SSL             |
+----------------+--------------------------------+
| example.com    | (LE In use) Valid until        |
|                | 2019-07-01 10:57:26 +0200 CEST |
| *.example.net  | (LE Error) Valid until         |
|                | 2019-04-12 19:40:07 +0200 CEST |
| *.example.eu   | (LE In use) Valid until        |
|                | 2019-06-12 09:00:11 +0200 CEST |
| example.net    |                              - |
| example.eu     |                              - |
+----------------+--------------------------------+

```