### PR TITLE
backup-download missing flags

### DIFF
--- a/cmd/backups.go
+++ b/cmd/backups.go
@@ -94,6 +94,7 @@ var (
 		Category:    backupsDownloadCommand.Category,
 		Usage:       backupsDownloadCommand.Usage,
 		Description: backupsDownloadCommand.Description,
+		Flags:       backupsDownloadCommand.Flags,
 		Before: func(*cli.Context) error {
 			io.Warningf("DEPRECATED: please use backups-download instead of this command\n\n")
 			return nil


### PR DESCRIPTION
```
╰─$ scalingo --app MY-APP backup-download --addon ad-78fbfa75-367d-53da-98a9-9d40d3ea0dac --backup 5d3e37018664ac757c331465
  /!\  DEPRECATED: please use backups-download instead of this command

 305 B / 305 B [==================================================================================================================================================================] 100.00% 0s
===> 20190729020001_my-app-3536.tar.gz
```

Fix #459