### PR TITLE
Display new SCM events

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -1,0 +1,1 @@
+--ignore-dir=bin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
   `integration-link-delete`, `integration-link-manual-deploy`,
   `integration-link-manual-review-app` commands
   [#458](https://github.com/Scalingo/cli/pull/458)
-* Add support for new SCM-related events [#467](https://github.com/Scalingo/cli/pull/467)
+* Add support for new SCM-related events
+  [#467](https://github.com/Scalingo/cli/pull/467) and
+  [#472](https://github.com/Scalingo/cli/pull/472)
 * Bugfix: Do not disconnect user if the API returns 401 [#462](https://github.com/Scalingo/cli/issues/462)
 * Add duration to the deployments list [#477](https://github.com/Scalingo/cli/issues/477)
 * Add support for new_user event [#473](https://github.com/Scalingo/cli/issues/473)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
   [#458](https://github.com/Scalingo/cli/pull/458)
 * Add support for new SCM-related events
   [#467](https://github.com/Scalingo/cli/pull/467) and
-  [#472](https://github.com/Scalingo/cli/pull/472)
+  [#458](https://github.com/Scalingo/cli/pull/458)
 * Bugfix: Do not disconnect user if the API returns 401 [#462](https://github.com/Scalingo/cli/issues/462)
 * Add duration to the deployments list [#477](https://github.com/Scalingo/cli/issues/477)
 * Add support for new_user event [#473](https://github.com/Scalingo/cli/issues/473)

--- a/scmintegrations/create.go
+++ b/scmintegrations/create.go
@@ -22,12 +22,12 @@ func Create(args CreateArgs) error {
 
 	integrationExist := checkIfIntegrationAlreadyExist(c, args.SCMType.Str())
 	if integrationExist {
-		io.Statusf("SCM Integration '%s' is already linked with your Scalingo account.\n", args.SCMType)
+		io.Statusf("SCM Integration '%s' is already linked with your Scalingo account.\n", scalingo.SCMTypeDisplay[args.SCMType])
 		return nil
 	}
 
 	if args.SCMType == scalingo.SCMGithubType || args.SCMType == scalingo.SCMGitlabType {
-		io.Statusf("Please follow this URL to create the %s SCM integration:\n", args.SCMType)
+		io.Statusf("Please follow this URL to create the %s SCM integration:\n", scalingo.SCMTypeDisplay[args.SCMType])
 		io.Statusf("%s/users/%s/link\n", config.C.ScalingoAuthUrl, args.SCMType)
 		return nil
 	}
@@ -37,6 +37,6 @@ func Create(args CreateArgs) error {
 		return errgo.Notef(err, "fail to create the SCM integration")
 	}
 
-	io.Statusf("Your Scalingo account has been linked to your '%s' account.\n", args.SCMType)
+	io.Statusf("Your Scalingo account has been linked to your %s account.\n", scalingo.SCMTypeDisplay[args.SCMType])
 	return nil
 }

--- a/scmintegrations/delete.go
+++ b/scmintegrations/delete.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Scalingo/cli/config"
 	"github.com/Scalingo/cli/io"
+	scalingo "github.com/Scalingo/go-scalingo"
 )
 
 func Delete(id string) error {
@@ -23,6 +24,6 @@ func Delete(id string) error {
 		return errgo.Notef(err, "fail to destroy SCM integration")
 	}
 
-	io.Statusf("Your Scalingo account and your '%s' account are unlinked.\n", integration.SCMType)
+	io.Statusf("Your Scalingo account and your %s account are unlinked.\n", scalingo.SCMTypeDisplay[integration.SCMType])
 	return nil
 }

--- a/scmintegrations/import_keys.go
+++ b/scmintegrations/import_keys.go
@@ -43,16 +43,16 @@ func ImportKeys(id string) error {
 			pluralKey = "s"
 		}
 
-		io.Statusf("0 key imported from %s.\n", integration.SCMType)
+		io.Statusf("0 key imported from %s.\n", scalingo.SCMTypeDisplay[integration.SCMType])
 		if alreadyImportedKeysLength == 0 {
-			io.Infof("No public key is available in your %s account\n", integration.SCMType)
+			io.Infof("No public key is available in your %s account\n", scalingo.SCMTypeDisplay[integration.SCMType])
 			return nil
 		}
 		io.Info()
 
 		io.Statusf(
 			"%d key%s have already been imported from %s:\n",
-			alreadyImportedKeysLength, pluralKey, integration.SCMType,
+			alreadyImportedKeysLength, pluralKey, scalingo.SCMTypeDisplay[integration.SCMType],
 		)
 		keys = alreadyImportedKeys
 	} else {
@@ -72,7 +72,7 @@ func ImportKeys(id string) error {
 		if nbrKeys > 1 {
 			pluralKey = "s"
 		}
-		io.Statusf("%d key%s have been imported from %s.\n", nbrKeys, pluralKey, integration.SCMType)
+		io.Statusf("%d key%s have been imported from %s.\n", nbrKeys, pluralKey, scalingo.SCMTypeDisplay[integration.SCMType])
 	}
 	return nil
 }

--- a/scmintegrations/list.go
+++ b/scmintegrations/list.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Scalingo/cli/config"
 	"github.com/Scalingo/cli/io"
+	scalingo "github.com/Scalingo/go-scalingo"
 )
 
 func List() error {
@@ -38,7 +39,7 @@ func List() error {
 	t.SetColWidth(60)
 	t.SetHeader([]string{"ID", "Type", "URL", "Username", "Email"})
 	for _, i := range integrations {
-		t.Append([]string{i.ID, i.SCMType.Str(), i.URL, i.Username, i.Email})
+		t.Append([]string{i.ID, scalingo.SCMTypeDisplay[i.SCMType], i.URL, i.Username, i.Email})
 	}
 	t.Render()
 	return nil


### PR DESCRIPTION
```
╰─$ go build -o ./scalingo/scalingo ./scalingo && SCALINGO_REGION=local SCALINGO_AUTH_URL=http://172.17.0.1:1234 SCALINGO_API_URL=http://172.17.0.1:3001 SSH_HOST=localhost:2200 ./scalingo/scalingo user-timeline
* Wed Aug 28 2019 15:19:41 - New Integration    - GitHub account 'EtienneM' has been authorized <admin-auth (admin-auth@scalingo.com)>
* Wed Aug 28 2019 15:19:41 - New Integration    - GitHub Enterprise (https://ghe.scalingo.com) account 'EtienneM' has been authorized <admin-auth (admin-auth@scalingo.com)>
* Wed Aug 28 2019 14:38:56 - Delete Integration - GitHub account 'EtienneM' has been revoked <admin-auth (admin-auth@scalingo.com)>

```

To be merged after ~https://github.com/Scalingo/go-scalingo/pull/135 and #458~

This PR was just an update of go-scalingo but I ended up updating it in #458 so there is not much left in this PR.... Just a changelog entry that is still worth the add and `.ackrc` file ^^

Related to Scalingo/authentication-service#299