### PR TITLE
Add support for new_user event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add support for new SCM-related events [#467](https://github.com/Scalingo/cli/pull/467)
 * Bugfix: Do not disconnect user if the API returns 401 [#462](https://github.com/Scalingo/cli/issues/462)
 * Add duration to the deployments list [#477](https://github.com/Scalingo/cli/issues/477)
+* Add support for new_user event [#473](https://github.com/Scalingo/cli/issues/473)
 
 ### 1.15.1
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,7 +10,7 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  digest = "1:a5f9d7f4806e4a7d9bcea5eb81f5d0c8faee5d4d49e9d157463601edf9d132f3"
+  digest = "1:0ad0aa9c48ef0dc07b2b2e51212698493d48c5d47c1e874f8ec6609471d2dc80"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -21,8 +21,8 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "1ab26f416f38103cf17310691f47eb23d8152993"
-  version = "v3.0.2"
+  revision = "aab97e66f012a256e7f39785fa1451d70258940b"
+  version = "v3.0.3"
 
 [[projects]]
   digest = "1:a1dcc4e2d5a5980c31901ea884435b64917fdd523eacb5d6171023b80eaa25a8"

--- a/vendor/github.com/Scalingo/go-scalingo/events_boilerplate.go
+++ b/vendor/github.com/Scalingo/go-scalingo/events_boilerplate.go
@@ -1,5 +1,8 @@
 package scalingo
 
+func (e *EventNewUserType) TypeDataPtr() interface{} {
+	return &e.TypeData
+}
 func (e *EventNewAppType) TypeDataPtr() interface{} {
 	return &e.TypeData
 }
@@ -30,16 +33,16 @@ func (e *EventLinkSCMType) TypeDataPtr() interface{} {
 func (e *EventUnlinkSCMType) TypeDataPtr() interface{} {
 	return &e.TypeData
 }
+func (e *EventNewIntegrationType) TypeDataPtr() interface{} {
+	return &e.TypeData
+}
+func (e *EventDeleteIntegrationType) TypeDataPtr() interface{} {
+	return &e.TypeData
+}
 func (e *EventAuthorizeGithubType) TypeDataPtr() interface{} {
 	return &e.TypeData
 }
 func (e *EventRevokeGithubType) TypeDataPtr() interface{} {
-	return &e.TypeData
-}
-func (e *EventAuthorizeGitLabType) TypeDataPtr() interface{} {
-	return &e.TypeData
-}
-func (e *EventRevokeGitLabType) TypeDataPtr() interface{} {
 	return &e.TypeData
 }
 func (e *EventRunType) TypeDataPtr() interface{} {

--- a/vendor/github.com/Scalingo/go-scalingo/events_structs.go
+++ b/vendor/github.com/Scalingo/go-scalingo/events_structs.go
@@ -64,6 +64,7 @@ type EventUser struct {
 type EventTypeName string
 
 const (
+	EventNewUser            EventTypeName = "new_user"
 	EventNewApp             EventTypeName = "new_app"
 	EventEditApp            EventTypeName = "edit_app"
 	EventDeleteApp          EventTypeName = "delete_app"
@@ -76,10 +77,10 @@ const (
 	EventDeployment         EventTypeName = "deployment"
 	EventLinkSCM            EventTypeName = "link_scm"
 	EventUnlinkSCM          EventTypeName = "unlink_scm"
+	EventNewIntegration     EventTypeName = "new_integration"
+	EventDeleteIntegration  EventTypeName = "delete_integration"
 	EventAuthorizeGithub    EventTypeName = "authorize_github"
-	EventAuthorizeGitLab    EventTypeName = "authorize_gitlab"
 	EventRevokeGithub       EventTypeName = "revoke_github"
-	EventRevokeGitLab       EventTypeName = "revoke_gitlab"
 	EventRun                EventTypeName = "run"
 	EventNewDomain          EventTypeName = "new_domain"
 	EventEditDomain         EventTypeName = "edit_domain"
@@ -116,6 +117,18 @@ const (
 	EventLinkGithub   EventTypeName = "link_github"
 	EventUnlinkGithub EventTypeName = "unlink_github"
 )
+
+type EventNewUserType struct {
+	Event
+	TypeData EventNewUserTypeData `json:"type_data"`
+}
+
+func (ev *EventNewUserType) String() string {
+	return fmt.Sprintf("You joined Scalingo. Hooray!")
+}
+
+type EventNewUserTypeData struct {
+}
 
 type EventNewAppType struct {
 	Event
@@ -851,6 +864,8 @@ func (pev *Event) Specialize() DetailedEvent {
 	var e DetailedEvent
 	ev := *pev
 	switch ev.Type {
+	case EventNewUser:
+		e = &EventNewUserType{Event: ev}
 	case EventNewApp:
 		e = &EventNewAppType{Event: ev}
 	case EventEditApp:
@@ -873,14 +888,14 @@ func (pev *Event) Specialize() DetailedEvent {
 		e = &EventLinkSCMType{Event: ev}
 	case EventUnlinkSCM:
 		e = &EventUnlinkSCMType{Event: ev}
+	case EventNewIntegration:
+		e = &EventNewIntegrationType{Event: ev}
+	case EventDeleteIntegration:
+		e = &EventDeleteIntegrationType{Event: ev}
 	case EventAuthorizeGithub:
 		e = &EventAuthorizeGithubType{Event: ev}
-	case EventAuthorizeGitLab:
-		e = &EventAuthorizeGitLabType{Event: ev}
 	case EventRevokeGithub:
 		e = &EventRevokeGithubType{Event: ev}
-	case EventRevokeGitLab:
-		e = &EventRevokeGitLabType{Event: ev}
 	case EventDeployment:
 		e = &EventDeploymentType{Event: ev}
 	case EventRun:

--- a/vendor/github.com/Scalingo/go-scalingo/events_user.go
+++ b/vendor/github.com/Scalingo/go-scalingo/events_user.go
@@ -2,6 +2,66 @@ package scalingo
 
 import "fmt"
 
+type EventNewIntegrationType struct {
+	Event
+	TypeData EventNewIntegrationTypeData `json:"type_data"`
+}
+
+func (ev *EventNewIntegrationType) String() string {
+	integrationType, ok := SCMTypeDisplay[ev.TypeData.IntegrationType]
+	if !ok {
+		integrationType = string(ev.TypeData.IntegrationType)
+	}
+	msg := fmt.Sprintf("%s", integrationType)
+
+	if ev.TypeData.IntegrationType == SCMGithubEnterpriseType ||
+		ev.TypeData.IntegrationType == SCMGitlabSelfHostedType {
+		msg = fmt.Sprintf("%s (%s)", msg, ev.TypeData.Data.URL)
+	}
+
+	return fmt.Sprintf("%s account '%s' has been authorized", msg, ev.TypeData.Data.Login)
+}
+
+type EventNewIntegrationTypeData struct {
+	IntegrationID   string  `json:"integration_id"`
+	IntegrationType SCMType `json:"integration_type"`
+	Data            struct {
+		Login     string `json:"login"`
+		AvatarURL string `json:"avatar_url"`
+		URL       string `json:"url"`
+	} `json:"data"`
+}
+
+type EventDeleteIntegrationType struct {
+	Event
+	TypeData EventDeleteIntegrationTypeData `json:"type_data"`
+}
+
+func (ev *EventDeleteIntegrationType) String() string {
+	integrationType, ok := SCMTypeDisplay[ev.TypeData.IntegrationType]
+	if !ok {
+		integrationType = string(ev.TypeData.IntegrationType)
+	}
+	msg := fmt.Sprintf("%s", integrationType)
+
+	if ev.TypeData.IntegrationType == SCMGithubEnterpriseType ||
+		ev.TypeData.IntegrationType == SCMGitlabSelfHostedType {
+		msg = fmt.Sprintf("%s (%s)", msg, ev.TypeData.Data.URL)
+	}
+
+	return fmt.Sprintf("%s account '%s' has been revoked", msg, ev.TypeData.Data.Login)
+}
+
+type EventDeleteIntegrationTypeData struct {
+	IntegrationID   string  `json:"integration_id"`
+	IntegrationType SCMType `json:"integration_type"`
+	Data            struct {
+		Login     string `json:"login"`
+		AvatarURL string `json:"avatar_url"`
+		URL       string `json:"url"`
+	} `json:"data"`
+}
+
 type EventAuthorizeGithubType struct {
 	Event
 	TypeData EventAuthorizeGithubTypeData `json:"type_data"`
@@ -16,30 +76,6 @@ type EventAuthorizeGithubTypeData struct {
 		Login     string `json:"login"`
 		AvatarURL string `json:"avatar_url"`
 	} `json:"github_user"`
-}
-
-type EventAuthorizeGitLabType struct {
-	Event
-	TypeData EventAuthorizeGitLabTypeData `json:"type_data"`
-}
-
-func (ev *EventAuthorizeGitLabType) String() string {
-	return fmt.Sprintf("GitLab account '%s' has been authorized", ev.TypeData.GitLabUser.Login)
-}
-
-type EventAuthorizeGitLabTypeData struct {
-	GitLabUser struct {
-		Login     string `json:"login"`
-		AvatarURL string `json:"avatar_url"`
-	} `json:"gitlab_user"`
-}
-
-type EventRevokeGitLabType struct {
-	Event
-}
-
-func (ev *EventRevokeGitLabType) String() string {
-	return fmt.Sprintf("GitLab authorization has been revoked")
 }
 
 type EventRevokeGithubType struct {

--- a/vendor/github.com/Scalingo/go-scalingo/scm_integrations.go
+++ b/vendor/github.com/Scalingo/go-scalingo/scm_integrations.go
@@ -16,6 +16,13 @@ const (
 	SCMGitlabSelfHostedType SCMType = "gitlab-self-hosted" // GitLab self-hosted (private instance)
 )
 
+var SCMTypeDisplay = map[SCMType]string{
+	SCMGithubType:           "GitHub",
+	SCMGitlabType:           "GitLab",
+	SCMGithubEnterpriseType: "GitHub Enterprise",
+	SCMGitlabSelfHostedType: "GitLab self-hosted",
+}
+
 func (t SCMType) Str() string {
 	return string(t)
 }


### PR DESCRIPTION
```
╰─$ go build -o ./scalingo/scalingo ./scalingo && SCALINGO_REGION=local SCALINGO_AUTH_URL=http://172.17.0.1:1234 SCALINGO_API_URL=http://172.17.0.1:3001 SSH_HOST=localhost:2200 ./scalingo/scalingo user-timeline
* Mon Jul 29 2019 09:38:43 - New User - You joined Scalingo. Hooray! <admin-auth (admin-auth@scalingo.com)>
```

Fix #471