### PR TITLE
Default destroy on stale is No

### DIFF
--- a/cmd/integration_link.go
+++ b/cmd/integration_link.go
@@ -344,7 +344,7 @@ func interactiveCreate() (scalingo.SCMRepoLinkParams, error) {
 	destroyOnClose := true
 	err = survey.AskOne(&survey.Confirm{
 		Message: "Automatically destroy review apps when the pull/merge request is closed:",
-		Default: true,
+		Default: destroyOnClose,
 	}, &destroyOnClose, nil)
 	if err != nil {
 		return params, err
@@ -364,10 +364,10 @@ func interactiveCreate() (scalingo.SCMRepoLinkParams, error) {
 		params.HoursBeforeDeleteOnClose = &hoursBeforeDestroyOnClose
 	}
 
-	destroyOnStale := true
+	destroyOnStale := false
 	err = survey.AskOne(&survey.Confirm{
 		Message: "Automatically destroy review apps after some time without deploy/commits:",
-		Default: true,
+		Default: destroyOnStale,
 	}, &destroyOnStale, nil)
 	if err != nil {
 		return params, err


### PR DESCRIPTION
```
╰─$ scalingo --app test-etienne integration-link-create https://framagit.org/Titizebioutifoul/sample-go-martini
? Branch to auto-deploy (empty to disable):
? Automatically deploy review apps: Yes
? Automatically destroy review apps when the pull/merge request is closed: Yes
? Hours before automatically destroying the review apps: 0
? Automatically destroy review apps after some time without deploy/commits: No
-----> Your app 'test-etienne' is linked to the repository https://framagit.org/Titizebioutifoul/sample-go-martini.
╭─emichon@biniou ~/Documents/Scalingo/golang/src/github.com/Scalingo/cli 2.4.2‹fix/484/default_destroy_stale*›
╰─$ scalingo --app test-etienne integration-link
Application: test-etienne (5d6d0d2bb4553d00019d22b6)
Integration: GitLab self-hosted (1ce487c9-3633-48be-b674-c87f2826f74f)

Repository: Titizebioutifoul/sample-go-martini
Auto Deploy: ✘
Review Apps Deploy: ✔
        Destroy on Close: instantly
        Destroy on Stale: ✘
```

Fix #484