### PR TITLE
Display a nice message when creating an app in a disabled region

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,7 +18,7 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  digest = "1:783cbace786278a2ffbde56d5aec37aa94e47c57ffba01967093b34c18b9b7d7"
+  digest = "1:2c5f09c29d50a9f8321bae28b6e376adf81116a069258f5889ab6860734ec524"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -29,8 +29,8 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "1bc7f634ed658b0a8499489673497715736ccb7a"
-  version = "v3.0.6"
+  revision = "11ac9402ccee4d1cc81dc6b89fa3d66d945bae0b"
+  version = "v3.0.7"
 
 [[projects]]
   digest = "1:a1dcc4e2d5a5980c31901ea884435b64917fdd523eacb5d6171023b80eaa25a8"

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -1,0 +1,15 @@
+package utils
+
+import (
+	"github.com/Scalingo/go-scalingo/http"
+	"github.com/Scalingo/go-utils/errors"
+)
+
+func IsRegionDisabledError(err error) bool {
+	reqerr, ok := errors.ErrgoRoot(err).(*http.RequestFailedError)
+	if !ok || reqerr.Code != 403 {
+		return false
+	}
+	httperr, ok := reqerr.APIError.(http.ForbiddenError)
+	return ok && httperr.Code == "region_disabled"
+}

--- a/vendor/github.com/Scalingo/go-scalingo/http/errors.go
+++ b/vendor/github.com/Scalingo/go-scalingo/http/errors.go
@@ -13,6 +13,7 @@ import (
 type (
 	BadRequestError struct {
 		ErrMessage string `json:"error"`
+		Code       string `json:"code"`
 	}
 
 	PaymentRequiredError struct {
@@ -27,7 +28,8 @@ type (
 	}
 
 	ForbiddenError struct {
-		Err string `json:"error"`
+		Err  string `json:"error"`
+		Code string `json:"code"`
 	}
 
 	UnprocessableEntity struct {


### PR DESCRIPTION
```
$ SCALINGO_REGION=agora-fr1 scalingo create totoapp
Application creation has been disabled on the currently used region: agora-fr1

Either configure your CLI to use another default region, then create your application:
    scalingo config --region osc-fr1
    scalingo create totoapp

Or use the region flag to specify the region explicitely for this command:
    scalingo --region osc-fr1 create totoapp

List of available regions:
- osc-fr1 (Paris - Outscale)
```