### PR TITLE
Add ability to pass --new-name to migration-create for same-region migration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -18,8 +18,7 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  branch = "feature/storky_run_endpoint"
-  digest = "1:ff5fc7b6104f84946f23df91d788310f9d64fd05ffa06d17d5ae00f892e57501"
+  digest = "1:841b02745d3c178285fe3fd510a7faaa87651c4c9939979805edb56040d28fbc"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -30,7 +29,8 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "e1374a7fb8bf6aade6f17212ece9b32829d03bb3"
+  revision = "226f5e46f779d41b3a3174f78571f4d8687b63c2"
+  version = "v3.0.8"
 
 [[projects]]
   digest = "1:a1dcc4e2d5a5980c31901ea884435b64917fdd523eacb5d6171023b80eaa25a8"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/Scalingo/go-scalingo"
-  branch = "feature/storky_run_endpoint"
+  version = "^3"
 
 [[constraint]]
   branch = "master"

--- a/cmd/region_migrations.go
+++ b/cmd/region_migrations.go
@@ -15,6 +15,7 @@ var (
 		Flags: []cli.Flag{
 			appFlag,
 			cli.StringFlag{Name: "to", Usage: "Select the destination region"},
+			cli.StringFlag{Name: "new-name", Usage: "Name of the app in the destination region (same as origin by default)"},
 		},
 		Usage: "Start a migrating an app to another region",
 		Description: `Migrate an app to another region.
@@ -33,7 +34,7 @@ var (
 				return
 			}
 
-			err := region_migrations.Create(currentApp, c.String("to"))
+			err := region_migrations.Create(currentApp, c.String("to"), c.String("new-name"))
 			if err != nil {
 				errorQuit(err)
 			}

--- a/region_migrations/confirmations.go
+++ b/region_migrations/confirmations.go
@@ -16,7 +16,6 @@ func ConfirmPrepare(migration scalingo.RegionMigration) bool {
 	fmt.Println(" - Import environment variables")
 	fmt.Println(" - Import SCM configuration")
 	fmt.Println(" - Import collaborators")
-	fmt.Println(" - Import SCM configuration")
 	fmt.Println(" - Import domains and TLS certificates")
 	fmt.Println(" - Import application settings")
 	fmt.Println(" - Import application formation")

--- a/region_migrations/refresher.go
+++ b/region_migrations/refresher.go
@@ -125,7 +125,7 @@ func (r *Refresher) writeMigration(w *uilive.Writer, migration *scalingo.RegionM
 	}
 
 	fmt.Fprintf(w, "Migration ID: %s\n", migration.ID)
-	fmt.Fprintf(w, "Migrating app: %s\n", migration.AppName)
+	fmt.Fprintf(w, "Migrating app: %s\n", migration.SrcAppName)
 	fmt.Fprintf(w.Newline(), "Destination: %s\n", migration.Destination)
 	if migration.NewAppID == "" {
 		fmt.Fprintf(w.Newline(), "New app ID: %s\n", color.BlueString("N/A"))

--- a/region_migrations/run.go
+++ b/region_migrations/run.go
@@ -8,7 +8,7 @@ import (
 	errgo "gopkg.in/errgo.v1"
 )
 
-func Create(app string, destination string) error {
+func Create(app string, destination string, dstAppName string) error {
 	c, err := config.ScalingoClient()
 	if err != nil {
 		return errgo.Notef(err, "fail to get scalingo client")
@@ -16,6 +16,7 @@ func Create(app string, destination string) error {
 
 	migration, err := c.CreateRegionMigration(app, scalingo.RegionMigrationParams{
 		Destination: destination,
+		DstAppName:  dstAppName,
 	})
 	if err != nil {
 		return errgo.Notef(err, "fail to create migration")

--- a/vendor/github.com/Scalingo/go-scalingo/region_migrations.go
+++ b/vendor/github.com/Scalingo/go-scalingo/region_migrations.go
@@ -38,11 +38,13 @@ type RegionMigrationsService interface {
 
 type RegionMigrationParams struct {
 	Destination string `json:"destination"`
+	DstAppName  string `json:"dst_app_name"`
 }
 
 type RegionMigration struct {
 	ID          string                `json:"id"`
-	AppName     string                `json:"app_name"`
+	SrcAppName  string                `json:"src_app_name"`
+	DstAppName  string                `json:"dst_app_name"`
 	AppID       string                `json:"app_id"`
 	NewAppID    string                `json:"new_app_id"`
 	Destination string                `json:"destination"`

--- a/vendor/github.com/Scalingo/go-scalingo/region_migrations.go
+++ b/vendor/github.com/Scalingo/go-scalingo/region_migrations.go
@@ -87,7 +87,7 @@ func (c *Client) RunRegionMigrationStep(appID, migrationID string, step RegionMi
 		Expected: http.Statuses{204},
 	}, nil)
 	if err != nil {
-		return errgo.Notef(err, "fail to schedule migration step")
+		return errgo.Notef(err, "fail to run migration step")
 	}
 	return nil
 }


### PR DESCRIPTION
Waiting for final release of go-scalingo