### PR TITLE
Fix: do not fail on short connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ### To be Released
 
+* Add `--bind` arg to `db-tunnel` command that let us bind a custom host (and not only 127.0.0.1) [#517](https://github.com/Scalingo/cli/pull/517)
+
 * Bugfix: Encrypted key with new OpenSSH format header for private keys was broken [#513](https://github.com/Scalingo/cli/pull/513)
+* Bugfix: db-tunnel: better handling of short lived connections  [#517](https://github.com/Scalingo/cli/pull/517)
 
 ### 1.16.4
 

--- a/cmd/db_tunnel.go
+++ b/cmd/db_tunnel.go
@@ -18,6 +18,7 @@ var (
 		Flags: []cli.Flag{appFlag,
 			cli.IntFlag{Name: "port, p", Usage: "Local port to bind (default 10000)"},
 			cli.StringFlag{Name: "identity, i", Usage: "SSH Private Key"},
+			cli.StringFlag{Name: "bind, b", Usage: "IP to bind (default 127.0.0.1)"},
 			cli.BoolTFlag{Name: "reconnect", Usage: "true by default, automatically reconnect to the tunnel when disconnected"},
 		},
 		Description: `Create an SSH-encrypted connection to access your Scalingo database locally.
@@ -71,6 +72,7 @@ var (
 				DBEnvVar:  c.Args()[0],
 				Identity:  sshIdentity,
 				Port:      c.Int("port"),
+				Bind:      c.String("bind"),
 				Reconnect: c.BoolT("reconnect"),
 			}
 			err := db.Tunnel(opts)

--- a/db/tunnel.go
+++ b/db/tunnel.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"errors"
 	"fmt"
 	stdio "io"
 	"net"
@@ -22,7 +21,6 @@ import (
 )
 
 var (
-	errTimeout      = errors.New("timeout")
 	connIDGenerator = make(chan int)
 	defaultPort     = 10000
 	defaultBind     = "127.0.0.1"
@@ -215,7 +213,7 @@ func handleConnToTunnel(sshClient *ssh.Client, dbUrl *url.URL, sock net.Conn, er
 			return nil
 		}
 
-		return errTimeout
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
Fix #516

* Do not reuse ssh.Signer, the connection to ssh agent might be broken
* Do not retry the connection if the server closed the connection
* Add --bind to db-tunnel to bind a custom command. This is helpful for docker setups where listening on localhost wont make it available on the docker0 interface