### PR TITLE
Improve error message when querying unknown app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### To be Released
 
+* Improve error message if unknown app, suggests to try on a different region
+  [#524](https://github.com/Scalingo/cli/pull/524)
+
 ### 1.16.6
 
 * Bugfix: integration-link-create: command will always fail if there's already a link [#520](https://github.com/Scalingo/cli/issues/520)

--- a/cmd/error.go
+++ b/cmd/error.go
@@ -84,6 +84,8 @@ func errorQuit(err error) {
 				region := strings.Split(apiURL.Host, ".")[1]
 				io.Errorf("The application was not found on the region %s.\n", region)
 				io.Error("You can try on a different region with 'scalingo --region osc-fr1 ...'.")
+				io.Error("")
+				io.Error("List of available regions is accessible with 'scalingo regions'.")
 			} else {
 				io.Error("An error occured:")
 				debug.Println(errgo.Details(err))

--- a/cmd/error.go
+++ b/cmd/error.go
@@ -85,7 +85,7 @@ func errorQuit(err error) {
 				io.Errorf("The application was not found on the region %s.\n", region)
 				io.Error("You can try on a different region with 'scalingo --region osc-fr1 ...'.")
 				io.Error("")
-				io.Error("List of available regions from your account is accessible with 'scalingo regions'.")
+				io.Error("List of available regions for your account is accessible with 'scalingo regions'.")
 			} else {
 				io.Error("An error occured:")
 				debug.Println(errgo.Details(err))

--- a/cmd/error.go
+++ b/cmd/error.go
@@ -85,7 +85,7 @@ func errorQuit(err error) {
 				io.Errorf("The application was not found on the region %s.\n", region)
 				io.Error("You can try on a different region with 'scalingo --region osc-fr1 ...'.")
 				io.Error("")
-				io.Error("List of available regions is accessible with 'scalingo regions'.")
+				io.Error("List of available regions from your account is accessible with 'scalingo regions'.")
 			} else {
 				io.Error("An error occured:")
 				debug.Println(errgo.Details(err))


### PR DESCRIPTION
```
╰─$ go build -o scalingo-cli ./scalingo && ./scalingo-cli --app unknown-app run bash
 !     The application was not found on the region agora-fr1.
 !     You can try on a different region with 'scalingo --region osc-fr1 ...'.
 !     
 !     List of available regions from your account is accessible with 'scalingo regions'.
```

Related to https://github.com/Scalingo/one-stop-shop/issues/34