### PR TITLE
Fix/cli/525/git setup remote already exists

### DIFF
--- a/cmd/git.go
+++ b/cmd/git.go
@@ -16,6 +16,9 @@ var (
 			cli.StringFlag{
 				Name: "remote, r", Value: "scalingo",
 				Usage: "Specify the remote name"},
+			cli.BoolFlag{
+				Name:  "force, f",
+				Usage: "Replace remote url even if remote already exist"},
 		},
 		Description: `Add a Git remote to the current folder.
 
@@ -29,7 +32,8 @@ var (
 			}
 
 			err := git.Setup(appdetect.CurrentApp(c), git.SetupParams{
-				RemoteName: c.String("r"),
+				RemoteName:     c.String("r"),
+				ForcePutRemote: c.Bool("f"),
 			})
 			if err != nil {
 				errorQuit(err)

--- a/cmd/git.go
+++ b/cmd/git.go
@@ -32,8 +32,8 @@ var (
 			}
 
 			err := git.Setup(appdetect.CurrentApp(c), git.SetupParams{
-				RemoteName:     c.String("r"),
-				ForcePutRemote: c.Bool("f"),
+				RemoteName:     c.String("remote"),
+				ForcePutRemote: c.Bool("force"),
 			})
 			if err != nil {
 				errorQuit(err)

--- a/git/setup.go
+++ b/git/setup.go
@@ -62,8 +62,8 @@ func createRemoteInRepository(repository *git.Repository, remoteName string, url
 	if err != nil {
 		errWrapped := utils.WrapError(err, "fail to create the Git remote")
 		if err == git.ErrRemoteExists {
-			errWrapped = utils.WrapError(err, "fail to create the Git remote"+
-				" (maybe you want use the force option to override the remote url)")
+			message := "Fail to configure git repository, '" + remoteName + "' remote already exists (use --force option to override)"
+			errWrapped = utils.WrapError(err, message)
 		}
 		return errWrapped
 	}

--- a/git/setup.go
+++ b/git/setup.go
@@ -63,7 +63,7 @@ func createRemoteInRepository(repository *git.Repository, remoteName string, url
 		errWrapped := utils.WrapError(err, "fail to create the Git remote")
 		if err == git.ErrRemoteExists {
 			errWrapped = utils.WrapError(err, "fail to create the Git remote"+
-				" (maybe you want use the force option to override the remote put)")
+				" (maybe you want use the force option to override the remote url)")
 		}
 		return errWrapped
 	}

--- a/git/setup.go
+++ b/git/setup.go
@@ -63,7 +63,7 @@ func createRemoteInRepository(repository *git.Repository, remoteName string, url
 		errWrapped := utils.WrapError(err, "fail to create the Git remote")
 		if err == git.ErrRemoteExists {
 			message := "Fail to configure git repository, '" + remoteName + "' remote already exists (use --force option to override)"
-			errWrapped = utils.WrapError(err, message)
+			errWrapped = utils.WrapError(errWrapped, message)
 		}
 		return errWrapped
 	}

--- a/git/setup.go
+++ b/git/setup.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"github.com/Scalingo/cli/io"
+	"github.com/Scalingo/cli/utils"
 	"github.com/Scalingo/go-scalingo/debug"
 	errgo "gopkg.in/errgo.v1"
 	git "gopkg.in/src-d/go-git.v4"
@@ -9,7 +10,8 @@ import (
 )
 
 type SetupParams struct {
-	RemoteName string
+	RemoteName     string
+	ForcePutRemote bool
 }
 
 func Setup(appName string, params SetupParams) error {
@@ -24,14 +26,66 @@ func Setup(appName string, params SetupParams) error {
 	}
 	debug.Println("Adding Git remote", url)
 
-	_, err = repo.CreateRemote(&gitconfig.RemoteConfig{
-		Name: params.RemoteName,
-		URLs: []string{url},
-	})
+	err = putRemoteInRepository(repo, params.RemoteName, url, params.ForcePutRemote)
 	if err != nil {
-		return errgo.Notef(err, "fail to add the Git remote")
+		return err
 	}
 
 	io.Status("Successfully added the Git remote", params.RemoteName, "on", appName)
 	return nil
+}
+
+func putRemoteInRepository(repository *git.Repository, remoteName string, url string, force bool) error {
+	has, err := repositoryHasRemote(repository, remoteName)
+	if err != nil {
+		return err
+	}
+	if has && force {
+		err := deleteThenCreateRemoteInRepository(repository, remoteName, url)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	err = createRemoteInRepository(repository, remoteName, url)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func createRemoteInRepository(repository *git.Repository, remoteName string, url string) error {
+	_, err := repository.CreateRemote(&gitconfig.RemoteConfig{
+		Name: remoteName,
+		URLs: []string{url},
+	})
+	if err != nil {
+		errWrapped := utils.WrapError(err, "fail to create the Git remote")
+		if err == git.ErrRemoteExists {
+			errWrapped = utils.WrapError(err, "fail to create the Git remote"+
+				" (maybe you want use the force option to override the remote put)")
+		}
+		return errWrapped
+	}
+	return nil
+}
+
+func deleteThenCreateRemoteInRepository(repository *git.Repository, remoteName string, url string) error {
+	err := repository.DeleteRemote(remoteName)
+	if err != nil {
+		return utils.WrapError(err, "fail to delete the Git remote")
+	}
+	return createRemoteInRepository(repository, remoteName, url)
+}
+
+func repositoryHasRemote(repository *git.Repository, remoteName string) (bool, error) {
+	config, err := repository.Storer.Config()
+	if err != nil {
+		return false, err
+	}
+
+	if _, has := config.Remotes[remoteName]; has {
+		return true, nil
+	}
+	return false, nil
 }

--- a/utils/errors.go
+++ b/utils/errors.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"github.com/Scalingo/go-scalingo/http"
 	"github.com/Scalingo/go-utils/errors"
+	"gopkg.in/errgo.v1"
 )
 
 func IsRegionDisabledError(err error) bool {
@@ -12,4 +13,8 @@ func IsRegionDisabledError(err error) bool {
 	}
 	httperr, ok := reqerr.APIError.(http.ForbiddenError)
 	return ok && httperr.Code == "region_disabled"
+}
+
+func WrapError(err error, wrappingMessage string) error {
+	return errgo.Notef(err, wrappingMessage)
 }


### PR DESCRIPTION
Offer a option --force to the command git-setup to allow the user to override the current remote handle with a new remote url

Fix #525 

User
- New flag "--force" on "git-seup"
- Suggestion message to use force when already remote handle already exist
Tech
- Propose change in errors management (using utils.Wrap instead of in place errgo.Notef)