### PR TITLE
Fix displaying of errors

### DIFF
--- a/apps/create.go
+++ b/apps/create.go
@@ -3,11 +3,12 @@ package apps
 import (
 	"fmt"
 
+	"gopkg.in/errgo.v1"
+
 	"github.com/Scalingo/cli/appdetect"
 	"github.com/Scalingo/cli/config"
 	"github.com/Scalingo/cli/utils"
 	"github.com/Scalingo/go-scalingo"
-	"gopkg.in/errgo.v1"
 )
 
 func Create(appName string, remote string, buildpack string) error {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"github.com/urfave/cli"
+
 	"github.com/Scalingo/cli/apps"
 	"github.com/Scalingo/cli/cmd/autocomplete"
-	"github.com/urfave/cli"
 )
 
 var (
@@ -19,7 +20,7 @@ var (
 		Usage: "Create a new app",
 		Action: func(c *cli.Context) {
 			if len(c.Args()) != 1 {
-				cli.ShowCommandHelp(c, "create")
+				_ = cli.ShowCommandHelp(c, "create")
 				return
 			}
 			err := apps.Create(c.Args()[0], c.String("remote"), c.String("buildpack"))
@@ -28,7 +29,7 @@ var (
 			}
 		},
 		BashComplete: func(c *cli.Context) {
-			autocomplete.CmdFlagsAutoComplete(c, "create")
+			_ = autocomplete.CmdFlagsAutoComplete(c, "create")
 		},
 	}
 )

--- a/cmd/error.go
+++ b/cmd/error.go
@@ -10,14 +10,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/stvp/rollbar"
+	"gopkg.in/errgo.v1"
+
 	"github.com/Scalingo/cli/config"
 	"github.com/Scalingo/cli/io"
 	"github.com/Scalingo/go-scalingo"
 	"github.com/Scalingo/go-scalingo/debug"
 	httpclient "github.com/Scalingo/go-scalingo/http"
 	"github.com/Scalingo/go-utils/errors"
-	"github.com/stvp/rollbar"
-	"gopkg.in/errgo.v1"
 )
 
 type Sysinfo struct {
@@ -38,7 +39,7 @@ type ReportError struct {
 }
 
 func (r *ReportError) Report() {
-	fields := []*rollbar.Field{&rollbar.Field{
+	fields := []*rollbar.Field{{
 		Name: "custom",
 		Data: r,
 	}}
@@ -87,18 +88,22 @@ func errorQuit(err error) {
 				io.Error("")
 				io.Error("List of available regions for your account is accessible with 'scalingo regions'.")
 			} else {
-				io.Error("An error occured:")
-				debug.Println(errgo.Details(err))
-				fmt.Println(io.Indent(err.Error(), 7))
+				printError(err)
 			}
+		} else {
+			printError(err)
 		}
 	} else {
-		io.Error("An error occured:")
-		debug.Println(errgo.Details(err))
-		fmt.Println(io.Indent(err.Error(), 7))
+		printError(err)
 	}
 
 	os.Exit(1)
+}
+
+func printError(err error) {
+	io.Error("An error occured:")
+	debug.Println(errgo.Details(err))
+	fmt.Println(io.Indent(err.Error(), 7))
 }
 
 func newReportError(currentUser *scalingo.User, err error) *ReportError {


### PR DESCRIPTION
Close #526 

Examples:
```bash
➜ ./main create te        
 !     An error occured:
       * name → should contain between 6 and 32 characters
```

```bash
➜ ./main -a test-cli integration-link-create https://github.com/scalingo/test
? Branch to auto-deploy (empty to disable): 
? Automatically deploy review apps: No
 !     An error occured:
       fail to create the repo link: fail to create the SCM repo link: server internal error - our team has been notified
```