### PR TITLE
Fix addon_updated, start_region_migration, restart and edit_variable event types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 * Region Migration: Better output for the `migration-follow` command to explain what is happening [#549](https://github.com/Scalingo/cli/pull/549)
 * Region Migration: Retry if it fails to refresh the migration status [#550](https://github.com/Scalingo/cli/pull/550)
-* Region Migration: Add instructions to change local Git URL at the end of the
-    migration [#551](https://github.com/Scalingo/cli/pull/551)
+* Region Migration: Add instructions to change local Git URL at the end of the migration [#551](https://github.com/Scalingo/cli/pull/551)
+* Bugfix: fix support for `addon_updated` and `start_region_migration` event type [#558](https://github.com/Scalingo/cli/pull/558)
+* Bugfix: fix author of `restart` and `edit_variable` when it's an addon [#558](https://github.com/Scalingo/cli/pull/558)
 
 ### 1.16.8
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,8 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  digest = "1:0ee4a78a86075261cb5694d7ea70291c9e3859f973592765d5027487ea1eb1f9"
+  branch = "fix/cli/556/addon_updated"
+  digest = "1:662e7b979add5743f8c20aa65801313105f875a1f226dfbecd75739c2aed556f"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -37,8 +38,7 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "0c39bed45efb25dccf24be48fec6cb699226de9b"
-  version = "v4.4.0"
+  revision = "ad496afff8110950ae0e07e7555fc3ee4873d5bb"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,8 @@
 
 [[constraint]]
   name = "github.com/Scalingo/go-scalingo"
-  version = "^4"
+  # version = "^4"
+  branch = "fix/cli/556/addon_updated"
 
 [[constraint]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,7 +46,7 @@
 
 [[constraint]]
   name = "github.com/urfave/cli"
-  version = "1.22.0"
+  version = "1.x"
 
 # Fix urfave/cli 1.22.0 dependency bug : https://github.com/urfave/cli/issues/888
 [[override]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -34,7 +34,7 @@
 
 [[constraint]]
   name = "github.com/cheggaaa/pb"
-  version = "1.0.28"
+  version = "1.x"
 
 [[constraint]]
   name = "github.com/Scalingo/go-utils"

--- a/vendor/github.com/Scalingo/go-scalingo/events_boilerplate.go
+++ b/vendor/github.com/Scalingo/go-scalingo/events_boilerplate.go
@@ -132,6 +132,12 @@ func (e *EventNewAutoscalerType) TypeDataPtr() interface{} {
 func (e *EventDeleteAutoscalerType) TypeDataPtr() interface{} {
 	return &e.TypeData
 }
+func (e *EventAddonUpdatedType) TypeDataPtr() interface{} {
+	return &e.TypeData
+}
+func (e *EventStartRegionMigrationType) TypeDataPtr() interface{} {
+	return &e.TypeData
+}
 func (e *EventLinkGithubType) TypeDataPtr() interface{} {
 	return &e.TypeData
 }


### PR DESCRIPTION
Fixed in the latest version of go-scalingo (https://github.com/Scalingo/go-scalingo/pull/161 and https://github.com/Scalingo/go-scalingo/pull/162)

```
╰─$ go build -o scalingo-cli ./scalingo && ./scalingo-cli --app biniou timeline
[...]
* Tue Mar 24 2020 11:17:53 - Addon Updated  - Addon PostgreSQL biniou_9013 updated, status provisioning -> running <scalingo-platform (deploy@scalingo.com)>
* Tue Mar 24 2020 11:17:53 - Restart        - containers have been restarted <Addon PostgreSQL>
* Tue Mar 24 2020 11:17:53 - Edit Variable  - 'SCALINGO_POSTGRESQL_URL' modified <Addon PostgreSQL>
[...]
```

   Fix #556
Fix #530 