### PR TITLE
Log drains list command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ main
 
 # IDE
 .idea/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Region Migration: Add instructions to change local Git URL at the end of the migration [#551](https://github.com/Scalingo/cli/pull/551)
 * Bugfix: fix support for `addon_updated` and `start_region_migration` event type [#558](https://github.com/Scalingo/cli/pull/558)
 * Bugfix: fix author of `restart` and `edit_variable` when it's an addon [#558](https://github.com/Scalingo/cli/pull/558)
+* Add log drains list command
+  [#560](https://github.com/Scalingo/cli/pull/560)
+  [go-scalingo #163](https://github.com/Scalingo/go-scalingo/pull/163)
 
 ### 1.16.8
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,8 +26,7 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  branch = "feature/cli/553/add_log_drains"
-  digest = "1:6915336e47aefcb2406f7f1d88f4a1a84daefc66c58869c66defd63db4e8cb20"
+  digest = "1:b7d56061e3b081a39b5a4865fe8d89399be57fee6c4a79cab6fb04f253893c94"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -38,7 +37,8 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "0b9beb56526ab6b14a1bec361e3713e8cf0a15ca"
+  revision = "b10cb76d5495cb1e040c58cb547bf608111af417"
+  version = "v4.5.0"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,8 +26,8 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  branch = "fix/cli/556/addon_updated"
-  digest = "1:662e7b979add5743f8c20aa65801313105f875a1f226dfbecd75739c2aed556f"
+  branch = "feature/cli/553/add_log_drains"
+  digest = "1:6915336e47aefcb2406f7f1d88f4a1a84daefc66c58869c66defd63db4e8cb20"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -38,7 +38,7 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "ad496afff8110950ae0e07e7555fc3ee4873d5bb"
+  revision = "0b9beb56526ab6b14a1bec361e3713e8cf0a15ca"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/Scalingo/go-scalingo"
-  branch = "feature/cli/553/add_log_drains"
+  version = "^4"
 
 [[constraint]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,8 +26,7 @@
 
 [[constraint]]
   name = "github.com/Scalingo/go-scalingo"
-  # version = "^4"
-  branch = "fix/cli/556/addon_updated"
+  branch = "feature/cli/553/add_log_drains"
 
 [[constraint]]
   branch = "master"

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -218,6 +218,9 @@ var (
 		migrationListCommand,
 		migrationFollowCommand,
 
+		// Log drains
+		logDrainsListCommand,
+
 		gitSetup,
 		gitShow,
 	}

--- a/cmd/log_drains.go
+++ b/cmd/log_drains.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"github.com/Scalingo/cli/appdetect"
+	"github.com/Scalingo/cli/cmd/autocomplete"
+	"github.com/Scalingo/cli/log_drains"
+	"github.com/urfave/cli"
+)
+
+var (
+	logDrainsListCommand = cli.Command{
+		Name:     "log-drains",
+		Category: "Log drains",
+		Flags:    []cli.Flag{appFlag},
+		Usage:    "List the log drains of an application",
+		Description: `List all the log drains of an application:
+
+    $ scalingo --app my-app log-drains`,
+
+		Action: func(c *cli.Context) {
+			currentApp := appdetect.CurrentApp(c)
+			if len(c.Args()) != 0 {
+				cli.ShowCommandHelp(c, "log-drains")
+				return
+			}
+
+			err := log_drains.List(currentApp)
+			if err != nil {
+				errorQuit(err)
+			}
+		},
+		BashComplete: func(c *cli.Context) {
+			autocomplete.CmdFlagsAutoComplete(c, "log-drains")
+		},
+	}
+)

--- a/log_drains/list.go
+++ b/log_drains/list.go
@@ -1,0 +1,34 @@
+package log_drains
+
+import (
+	"os"
+
+	"github.com/Scalingo/cli/config"
+	"github.com/olekukonko/tablewriter"
+	"gopkg.in/errgo.v1"
+)
+
+func List(app string) error {
+	c, err := config.ScalingoClient()
+	if err != nil {
+		return errgo.Notef(err, "fail to get Scalingo client")
+	}
+
+	logDrains, err := c.LogDrainsList(app)
+	if err != nil {
+		return errgo.Notef(err, "fail to list the log drains")
+	}
+
+	t := tablewriter.NewWriter(os.Stdout)
+
+	t.SetHeader([]string{"URL"})
+
+	for _, logDrain := range logDrains {
+		t.Append([]string{
+			logDrain.URL,
+		})
+	}
+
+	t.Render()
+	return nil
+}

--- a/vendor/github.com/Scalingo/go-scalingo/client.go
+++ b/vendor/github.com/Scalingo/go-scalingo/client.go
@@ -22,6 +22,7 @@ type API interface {
 	EventsService
 	KeysService
 	LoginService
+	LogDrainsService
 	LogsArchivesService
 	LogsService
 	NotificationPlatformsService

--- a/vendor/github.com/Scalingo/go-scalingo/events_structs.go
+++ b/vendor/github.com/Scalingo/go-scalingo/events_structs.go
@@ -218,9 +218,17 @@ func (ev *EventRestartType) String() string {
 	return fmt.Sprintf("containers have been restarted")
 }
 
+func (ev *EventRestartType) Who() string {
+	if ev.TypeData.AddonName != "" {
+		return fmt.Sprintf("Addon %s", ev.TypeData.AddonName)
+	} else {
+		return ev.Who()
+	}
+}
+
 type EventRestartTypeData struct {
-	Scope         []string `json:"scope"`
-	AddonProvider string   `json:"addon_provider"`
+	Scope     []string `json:"scope"`
+	AddonName string   `json:"addon_name"`
 }
 
 type EventStopAppType struct {
@@ -644,7 +652,8 @@ func (ev *EventEditVariableType) String() string {
 
 type EventEditVariableTypeData struct {
 	EventVariable
-	OldValue string `json:"old_value"`
+	OldValue  string `json:"old_value"`
+	AddonName string `json:"addon_name"`
 }
 
 type EventEditVariablesType struct {
@@ -664,6 +673,14 @@ func (ev *EventEditVariablesType) String() string {
 		res += fmt.Sprintf(" %s removed", ev.TypeData.DeletedVars.Names())
 	}
 	return res
+}
+
+func (ev *EventEditVariableType) Who() string {
+	if ev.TypeData.AddonName != "" {
+		return fmt.Sprintf("Addon %s", ev.TypeData.AddonName)
+	} else {
+		return ev.Who()
+	}
 }
 
 type EventEditVariablesTypeData struct {

--- a/vendor/github.com/Scalingo/go-scalingo/log_drains.go
+++ b/vendor/github.com/Scalingo/go-scalingo/log_drains.go
@@ -1,0 +1,25 @@
+package scalingo
+
+import (
+	"gopkg.in/errgo.v1"
+)
+
+type LogDrainsService interface {
+	LogDrainsList(app string) ([]LogDrain, error)
+}
+
+var _ LogDrainsService = (*Client)(nil)
+
+type LogDrain struct {
+	AppID string `json:"app_id"`
+	URL   string `json:"url"`
+}
+
+func (c *Client) LogDrainsList(app string) ([]LogDrain, error) {
+	var logDrainsRes []LogDrain
+	err := c.ScalingoAPI().SubresourceList("apps", app, "log_drains", nil, &logDrainsRes)
+	if err != nil {
+		return nil, errgo.Notef(err, "fail to list the log drains")
+	}
+	return logDrainsRes, nil
+}

--- a/vendor/github.com/Scalingo/go-scalingo/version.go
+++ b/vendor/github.com/Scalingo/go-scalingo/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "4.4.0"
+var Version = "4.4.1"

--- a/vendor/github.com/Scalingo/go-scalingo/version.go
+++ b/vendor/github.com/Scalingo/go-scalingo/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "4.4.1"
+var Version = "4.5.0"


### PR DESCRIPTION
- Add list command
- Add a vsocde config file to debug CLI


Example
```bash
$ scalingo log-drains --app my-app
+------------------------------------+
|                 URL                |
+------------------------------------+
| ovh://:id@region.logs.ovh.com:6514 |
| tcp+tls://localhost:10303          |
+------------------------------------+
```

Fix #553 