### PR TITLE
Log drains add command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 * Deployment: Send a non 0 exit code when a deployment fails [#563](https://github.com/Scalingo/cli/pull/563)
 * Bugfix: fix support for `addon_updated` and `start_region_migration` event type [#558](https://github.com/Scalingo/cli/pull/558)
 * Bugfix: fix author of `restart` and `edit_variable` when it's an addon [#558](https://github.com/Scalingo/cli/pull/558)
+* Add log drains add command
+  [#561](https://github.com/Scalingo/cli/pull/561)
+  [go-scalingo #164](https://github.com/Scalingo/go-scalingo/pull/164)
+
 
 ### 1.16.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Add log drains list command
   [#560](https://github.com/Scalingo/cli/pull/560)
   [go-scalingo #163](https://github.com/Scalingo/go-scalingo/pull/163)
+* Add log drains add command
+  [#561](https://github.com/Scalingo/cli/pull/561)
+  [go-scalingo #164](https://github.com/Scalingo/go-scalingo/pull/164)
 
 ### 1.17.0
 
@@ -14,10 +17,6 @@
 * Deployment: Send a non 0 exit code when a deployment fails [#563](https://github.com/Scalingo/cli/pull/563)
 * Bugfix: fix support for `addon_updated` and `start_region_migration` event type [#558](https://github.com/Scalingo/cli/pull/558)
 * Bugfix: fix author of `restart` and `edit_variable` when it's an addon [#558](https://github.com/Scalingo/cli/pull/558)
-* Add log drains add command
-  [#561](https://github.com/Scalingo/cli/pull/561)
-  [go-scalingo #164](https://github.com/Scalingo/go-scalingo/pull/164)
-
 
 ### 1.16.8
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,8 +26,7 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  branch = "feature/cli/552/add_log_drains_add_cmd"
-  digest = "1:442ab5e7dc24d4061780441346fa268011aa5e7f7f9ec0d9ce1a8a23c8ff43a1"
+  digest = "1:13f8c81c5ca5de26437177f7e63da07a703b45cb0dac9f4141beef0cd448cad2"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -38,7 +37,8 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "3d57e090bfec57f81fbfb726604a580f766ccac7"
+  revision = "9f30cefb0ea118d42f84c30964bbb3a842f004be"
+  version = "v4.5.2"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,8 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  digest = "1:5316b9e338b0a202d95a3268b5875a72b6ab0ae6c671d1c12428afd4b00d4e48"
+  branch = "feature/cli/552/add_log_drains_add_cmd"
+  digest = "1:de5c8e3866221e5dface16c8660b3200717321119831f282f221ba8dbbac19bc"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -37,8 +38,7 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "af764fd9e5110a35a430869fb387d62315c28855"
-  version = "v4.5.1"
+  revision = "2921a67e8f9fd8a9f104e13534e8127c97c75fff"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,7 +27,7 @@
 
 [[projects]]
   branch = "feature/cli/552/add_log_drains_add_cmd"
-  digest = "1:de5c8e3866221e5dface16c8660b3200717321119831f282f221ba8dbbac19bc"
+  digest = "1:442ab5e7dc24d4061780441346fa268011aa5e7f7f9ec0d9ce1a8a23c8ff43a1"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -38,7 +38,7 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "2921a67e8f9fd8a9f104e13534e8127c97c75fff"
+  revision = "3d57e090bfec57f81fbfb726604a580f766ccac7"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/Scalingo/go-scalingo"
-  version = "^4"
+  branch = "feature/cli/552/add_log_drains_add_cmd"
 
 [[constraint]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/Scalingo/go-scalingo"
-  branch = "feature/cli/552/add_log_drains_add_cmd"
+  version = "^4"
 
 [[constraint]]
   branch = "master"

--- a/README.md
+++ b/README.md
@@ -219,8 +219,6 @@ GLOBAL OPTIONS:
    --remote value, -r value  Name of the remote (default: "scalingo")
    --region value            Name of the region to use
    --version, -v             print the version
-
-Fail to run command: flag: help requested
 ```
 
 ## Development Setup

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ COMMANDS:
    App Management:
      destroy                 Destroy an app /!\
      rename                  Rename an application
+     apps-info               Display the application information
      logs, l                 Get the logs of your applications
      logs-archives, la       Get the logs archives of your applications
      run, r                  Run any command for your app
@@ -162,15 +163,14 @@ COMMANDS:
      logout     Logout from Scalingo
      regions    List available regions
      config     Configure the CLI
-     signup     Create your Scalingo account
      self       Get the logged in profile
      whoami     Get the logged in profile
 
    Integration Link:
-     integration-link                    Show repo link linked with your app
-     integration-link-create             Create a repo link between your scm integration and your app
-     integration-link-update             Update the repo link linked with your app
-     integration-link-delete             Delete repo link linked with your app
+     integration-link                    Show integration link of your app
+     integration-link-create             Link your Scalingo application to an integration
+     integration-link-update             Update the integration link parameters
+     integration-link-delete             Delete the link between your Scalingo application and the integration
      integration-link-manual-deploy      Trigger a manual deployment of the specified branch
      integration-link-manual-review-app  Trigger a review app creation of the pull/merge request ID specified
 
@@ -179,6 +179,10 @@ COMMANDS:
      integrations-add          Link your Scalingo account with your account on a tool such as github.com
      integrations-delete       Unlink your Scalingo account and your account on a tool such as github.com
      integrations-import-keys  Import public SSH keys from integration account
+
+   Log drains:
+     log-drains-add  Add a log drain to an application
+     log-drains      List the log drains of an application
 
    Notifiers:
      notifiers          List your notifiers
@@ -196,12 +200,14 @@ COMMANDS:
      keys-remove  Remove a public SSH key
 
    Region migrations:
-     migrations-create  Migrate an app to another region
-     migrations         List all migrations linked to an app
-     migrations-follow  Follow a running migration
+     migration-create  Start migrating an app to another region
+     migration-run     Run a specific migration step
+     migration-abort   Abort a migration
+     migrations        List all migrations linked to an app
+     migration-follow  Follow a running migration
 
    Review Apps:
-     review-apps  See review apps of parent application
+     review-apps  Show review apps of the parent application
 
    Runtime Stacks:
      stacks      List the available runtime stacks
@@ -213,6 +219,8 @@ GLOBAL OPTIONS:
    --remote value, -r value  Name of the remote (default: "scalingo")
    --region value            Name of the region to use
    --version, -v             print the version
+
+Fail to run command: flag: help requested
 ```
 
 ## Development Setup

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -219,6 +219,7 @@ var (
 		migrationFollowCommand,
 
 		// Log drains
+		logDrainsAddCommand,
 		logDrainsListCommand,
 
 		gitSetup,

--- a/cmd/log_drains.go
+++ b/cmd/log_drains.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Scalingo/cli/appdetect"
 	"github.com/Scalingo/cli/cmd/autocomplete"
 	"github.com/Scalingo/cli/log_drains"
+	"github.com/Scalingo/go-scalingo"
 	"github.com/urfave/cli"
 )
 
@@ -15,7 +16,9 @@ var (
 		Usage:    "List the log drains of an application",
 		Description: `List all the log drains of an application:
 
-    $ scalingo --app my-app log-drains`,
+	$ scalingo --app my-app log-drains
+
+	# See also commands 'log-drains-add'`,
 
 		Action: func(c *cli.Context) {
 			currentApp := appdetect.CurrentApp(c)
@@ -25,6 +28,50 @@ var (
 			}
 
 			err := log_drains.List(currentApp)
+			if err != nil {
+				errorQuit(err)
+			}
+		},
+		BashComplete: func(c *cli.Context) {
+			autocomplete.CmdFlagsAutoComplete(c, "log-drains")
+		},
+	}
+
+	logDrainsAddCommand = cli.Command{
+		Name:     "log-drains-add",
+		Category: "Log drains",
+		Usage:    "Add a log drains to an application",
+		Flags: []cli.Flag{appFlag,
+			cli.StringFlag{Name: "type", Usage: "Communication protocol", Required: true},
+			cli.StringFlag{Name: "url", Usage: "URL of self hosted ELK"},
+			cli.StringFlag{Name: "host", Usage: "Host of logs management service"},
+			cli.StringFlag{Name: "port", Usage: "Port of logs management service"},
+			cli.StringFlag{Name: "token", Usage: "Used by certain vendor for authentication"},
+			cli.StringFlag{Name: "drain-region", Usage: "Region used by logs management service to identify their servers"},
+		},
+		Description: `Add a log drain to an application:
+
+	Examples:
+		$ scalingo -a myapp log-drains-add --type datadog --token token --drain-region region
+		$ scalingo -a myapp log-drains-add --type ovh-graylog --token token --host tag1.logs.ovh.com
+		$ scalingo -a myapp log-drains-add --type logentries --token token
+		$ scalingo -a myapp log-drains-add --type papertrail --host logsN.papertrailapp.com --port 12345
+		$ scalingo -a myapp log-drains-add --type syslog --host example.com --port 12345
+		$ scalingo -a myapp log-drains-add --type elk --url https://USER:TOKEN@logstash-app-name.osc-fr1.scalingo.io
+
+	# See also commands 'log-drains'`,
+
+		Action: func(c *cli.Context) {
+			currentApp := appdetect.CurrentApp(c)
+
+			err := log_drains.Add(currentApp, scalingo.LogDrainAddParams{
+				Type:        c.String("type"),
+				URL:         c.String("url"),
+				Host:        c.String("host"),
+				Port:        c.String("port"),
+				Token:       c.String("token"),
+				DrainRegion: c.String("drain-region"),
+			})
 			if err != nil {
 				errorQuit(err)
 			}

--- a/cmd/log_drains.go
+++ b/cmd/log_drains.go
@@ -40,24 +40,24 @@ var (
 	logDrainsAddCommand = cli.Command{
 		Name:     "log-drains-add",
 		Category: "Log drains",
-		Usage:    "Add a log drains to an application",
+		Usage:    "Add a log drain to an application",
 		Flags: []cli.Flag{appFlag,
 			cli.StringFlag{Name: "type", Usage: "Communication protocol", Required: true},
 			cli.StringFlag{Name: "url", Usage: "URL of self hosted ELK"},
 			cli.StringFlag{Name: "host", Usage: "Host of logs management service"},
 			cli.StringFlag{Name: "port", Usage: "Port of logs management service"},
 			cli.StringFlag{Name: "token", Usage: "Used by certain vendor for authentication"},
-			cli.StringFlag{Name: "drain-region", Usage: "Region used by logs management service to identify their servers"},
+			cli.StringFlag{Name: "drain-region", Usage: "Used by certain logs management service to identify the region of their servers"},
 		},
 		Description: `Add a log drain to an application:
 
 	Examples:
-		$ scalingo -a myapp log-drains-add --type datadog --token token --drain-region region
-		$ scalingo -a myapp log-drains-add --type ovh-graylog --token token --host tag1.logs.ovh.com
-		$ scalingo -a myapp log-drains-add --type logentries --token token
-		$ scalingo -a myapp log-drains-add --type papertrail --host logsN.papertrailapp.com --port 12345
-		$ scalingo -a myapp log-drains-add --type syslog --host example.com --port 12345
-		$ scalingo -a myapp log-drains-add --type elk --url https://USER:TOKEN@logstash-app-name.osc-fr1.scalingo.io
+		$ scalingo --app my-app log-drains-add --type datadog --token 123456789abcdef --drain-region eu-west-2
+		$ scalingo --app my-app log-drains-add --type ovh-graylog --token 123456789abcdef --host tag3.logs.ovh.com
+		$ scalingo --app my-app log-drains-add --type logentries --token 123456789abcdef
+		$ scalingo --app my-app log-drains-add --type papertrail --host logs2.papertrailapp.com --port 12345
+		$ scalingo --app my-app log-drains-add --type syslog --host custom.logstash.com --port 12345
+		$ scalingo --app my-app log-drains-add --type elk --url https://my-user:123456789abcdef@logstash-app-name.osc-fr1.scalingo.io
 
 	# See also commands 'log-drains'`,
 

--- a/log_drains/add.go
+++ b/log_drains/add.go
@@ -18,6 +18,6 @@ func Add(app string, params scalingo.LogDrainAddParams) error {
 		return errgo.Notef(err, "fail to add drain to the application")
 	}
 
-	io.Status("Log drain", d.Drain.URL, "has been added to the application")
+	io.Status("Log drain", d.Drain.URL, "has been added to the application", app)
 	return nil
 }

--- a/log_drains/add.go
+++ b/log_drains/add.go
@@ -1,0 +1,24 @@
+package log_drains
+
+import (
+	"github.com/Scalingo/cli/config"
+	"github.com/Scalingo/cli/io"
+	"github.com/Scalingo/go-scalingo"
+	"gopkg.in/errgo.v1"
+)
+
+func Add(app string, params scalingo.LogDrainAddParams) error {
+	c, err := config.ScalingoClient()
+	if err != nil {
+		return errgo.Notef(err, "fail to get Scalingo client")
+	}
+
+	d, err := c.LogDrainAdd(app, params)
+
+	if err != nil {
+		return errgo.Notef(err, "fail to add drain to the application")
+	}
+
+	io.Status("Log Drain", d.Drain.URL, "has been add to the application")
+	return nil
+}

--- a/log_drains/add.go
+++ b/log_drains/add.go
@@ -10,15 +10,14 @@ import (
 func Add(app string, params scalingo.LogDrainAddParams) error {
 	c, err := config.ScalingoClient()
 	if err != nil {
-		return errgo.Notef(err, "fail to get Scalingo client")
+		return errgo.Notef(err, "fail to get Scalingo client to add a log drain")
 	}
 
 	d, err := c.LogDrainAdd(app, params)
-
 	if err != nil {
 		return errgo.Notef(err, "fail to add drain to the application")
 	}
 
-	io.Status("Log Drain", d.Drain.URL, "has been add to the application")
+	io.Status("Log drain", d.Drain.URL, "has been added to the application")
 	return nil
 }

--- a/vendor/github.com/Scalingo/go-scalingo/log_drains.go
+++ b/vendor/github.com/Scalingo/go-scalingo/log_drains.go
@@ -1,7 +1,6 @@
 package scalingo
 
 import (
-	httpclient "github.com/Scalingo/go-scalingo/http"
 	"gopkg.in/errgo.v1"
 )
 
@@ -22,13 +21,8 @@ type LogDrain struct {
 	DrainRegion string `json:"drain_region"`
 }
 
-type logDrainReq struct {
-	Drain LogDrain `json:"drain"`
-}
-
 type LogDrainRes struct {
 	Drain LogDrain `json:"drain"`
-	Error string   `json:"error"`
 }
 
 func (c *Client) LogDrainsList(app string) ([]LogDrain, error) {
@@ -51,7 +45,7 @@ type LogDrainAddParams struct {
 
 func (c *Client) LogDrainAdd(app string, params LogDrainAddParams) (*LogDrainRes, error) {
 	var logDrainRes LogDrainRes
-	payload := logDrainReq{
+	payload := LogDrainRes{
 		Drain: LogDrain{
 			Type:        params.Type,
 			URL:         params.URL,
@@ -62,20 +56,9 @@ func (c *Client) LogDrainAdd(app string, params LogDrainAddParams) (*LogDrainRes
 		},
 	}
 
-	req := &httpclient.APIRequest{
-		Method:   "POST",
-		Endpoint: "/apps/" + app + "/log_drains",
-		Expected: httpclient.Statuses{201, 422},
-		Params:   payload,
-	}
-
-	err := c.ScalingoAPI().DoRequest(req, &logDrainRes)
+	err := c.ScalingoAPI().SubresourceAdd("apps", app, "log_drains", payload, &logDrainRes)
 	if err != nil {
 		return nil, errgo.Notef(err, "fail to add drain")
-	}
-
-	if logDrainRes.Error != "" {
-		return nil, errgo.Notef(err, logDrainRes.Error)
 	}
 
 	return &logDrainRes, nil

--- a/vendor/github.com/Scalingo/go-scalingo/log_drains.go
+++ b/vendor/github.com/Scalingo/go-scalingo/log_drains.go
@@ -1,18 +1,34 @@
 package scalingo
 
 import (
+	httpclient "github.com/Scalingo/go-scalingo/http"
 	"gopkg.in/errgo.v1"
 )
 
 type LogDrainsService interface {
 	LogDrainsList(app string) ([]LogDrain, error)
+	LogDrainAdd(app string, params LogDrainAddParams) (*LogDrainRes, error)
 }
 
 var _ LogDrainsService = (*Client)(nil)
 
 type LogDrain struct {
-	AppID string `json:"app_id"`
-	URL   string `json:"url"`
+	AppID       string `json:"app_id"`
+	URL         string `json:"url"`
+	Type        string `json:"type"`
+	Host        string `json:"host"`
+	Port        string `json:"port"`
+	Token       string `json:"token"`
+	DrainRegion string `json:"drain_region"`
+}
+
+type logDrainReq struct {
+	Drain LogDrain `json:"drain"`
+}
+
+type LogDrainRes struct {
+	Drain LogDrain `json:"drain"`
+	Error string   `json:"error"`
 }
 
 func (c *Client) LogDrainsList(app string) ([]LogDrain, error) {
@@ -22,4 +38,45 @@ func (c *Client) LogDrainsList(app string) ([]LogDrain, error) {
 		return nil, errgo.Notef(err, "fail to list the log drains")
 	}
 	return logDrainsRes, nil
+}
+
+type LogDrainAddParams struct {
+	Type        string `json:"type"`
+	URL         string `json:"url"`
+	Port        string `json:"port"`
+	Host        string `json:"host"`
+	Token       string `json:"token"`
+	DrainRegion string `json:"drain_region"`
+}
+
+func (c *Client) LogDrainAdd(app string, params LogDrainAddParams) (*LogDrainRes, error) {
+	var logDrainRes LogDrainRes
+	payload := logDrainReq{
+		Drain: LogDrain{
+			Type:        params.Type,
+			URL:         params.URL,
+			Host:        params.Host,
+			Port:        params.Port,
+			Token:       params.Token,
+			DrainRegion: params.DrainRegion,
+		},
+	}
+
+	req := &httpclient.APIRequest{
+		Method:   "POST",
+		Endpoint: "/apps/" + app + "/log_drains",
+		Expected: httpclient.Statuses{201, 422},
+		Params:   payload,
+	}
+
+	err := c.ScalingoAPI().DoRequest(req, &logDrainRes)
+	if err != nil {
+		return nil, errgo.Notef(err, "fail to add drain")
+	}
+
+	if logDrainRes.Error != "" {
+		return nil, errgo.Notef(err, logDrainRes.Error)
+	}
+
+	return &logDrainRes, nil
 }

--- a/vendor/github.com/Scalingo/go-scalingo/version.go
+++ b/vendor/github.com/Scalingo/go-scalingo/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "4.5.1"
+var Version = "4.5.2"


### PR DESCRIPTION
- Add `log-drains-add` command

Example
```bash
$ scalingo log-drains-add --app sample-go-martini --type papertrail --host logs.papertrailapp.com --port 12345
-----> Log Drain tcp+tls://logs.papertrailapp.com:12345 has been add to the application
```

Fix #552 