### PR TITLE
Log drains: delete command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Add log drains add command
   [#561](https://github.com/Scalingo/cli/pull/561)
   [go-scalingo #164](https://github.com/Scalingo/go-scalingo/pull/164)
+* Add log drains delete command
+  [#567](https://github.com/Scalingo/cli/pull/567)
+  [go-scalingo #167](https://github.com/Scalingo/go-scalingo/pull/167)
 
 ### 1.17.0
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,7 +27,7 @@
 
 [[projects]]
   branch = "feature/cli/554/add_log_drains_del_cmd"
-  digest = "1:de17197855c36bda72c0fee89959ca4f745e893a5185f3f9f26dab316975f13b"
+  digest = "1:a1635c85bc0f760bbc43b180f4dd51e04d8a1774752268cb555446435c46b402"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -38,7 +38,7 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "b83c1952fb9b04dc04e0e4281d0e94cc2b366240"
+  revision = "ea8f03c8a69643e438a23d25afc24eb0b3686498"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,7 +27,7 @@
 
 [[projects]]
   branch = "feature/cli/554/add_log_drains_del_cmd"
-  digest = "1:a1635c85bc0f760bbc43b180f4dd51e04d8a1774752268cb555446435c46b402"
+  digest = "1:07201e6d503d992dfe159527dac247af0a27b3ec608e958d10ba77b98055f708"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -38,7 +38,7 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "ea8f03c8a69643e438a23d25afc24eb0b3686498"
+  revision = "0f54664864f4de65ff77cb47eb1eb79eaf16a63b"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,7 +27,7 @@
 
 [[projects]]
   branch = "feature/cli/554/add_log_drains_del_cmd"
-  digest = "1:40ae488a4e927a7c247abd84487118d38f19bbd400b65747d2818fa03424afb7"
+  digest = "1:de17197855c36bda72c0fee89959ca4f745e893a5185f3f9f26dab316975f13b"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -38,7 +38,7 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "2feae75efa770bc5833d58f652c3690efc7fe125"
+  revision = "b83c1952fb9b04dc04e0e4281d0e94cc2b366240"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,8 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  digest = "1:13f8c81c5ca5de26437177f7e63da07a703b45cb0dac9f4141beef0cd448cad2"
+  branch = "feature/cli/554/add_log_drains_del_cmd"
+  digest = "1:40ae488a4e927a7c247abd84487118d38f19bbd400b65747d2818fa03424afb7"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -37,8 +38,7 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "9f30cefb0ea118d42f84c30964bbb3a842f004be"
-  version = "v4.5.2"
+  revision = "2feae75efa770bc5833d58f652c3690efc7fe125"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,8 +26,7 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  branch = "feature/cli/554/add_log_drains_del_cmd"
-  digest = "1:07201e6d503d992dfe159527dac247af0a27b3ec608e958d10ba77b98055f708"
+  digest = "1:08eece729c1bef63ba65ac49a2dda812a07c69f489178917c6fe227f8d89301e"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -38,7 +37,8 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "0f54664864f4de65ff77cb47eb1eb79eaf16a63b"
+  revision = "69d49c22431d4655ab091eeb3e527de5413e67e6"
+  version = "v4.5.3"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/Scalingo/go-scalingo"
-  branch = "feature/cli/554/add_log_drains_del_cmd"
+   version = "^4"
 
 [[constraint]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/Scalingo/go-scalingo"
-  version = "^4"
+  branch = "feature/cli/554/add_log_drains_del_cmd"
 
 [[constraint]]
   branch = "master"

--- a/cmd/autocomplete/domains_remove.go
+++ b/cmd/autocomplete/domains_remove.go
@@ -19,11 +19,12 @@ func DomainsRemoveAutoComplete(c *cli.Context) error {
 		return errgo.Notef(err, "fail to get Scalingo client")
 	}
 	domains, err := client.DomainsList(appName)
-	if err == nil {
+	if err != nil {
+		return errgo.Notef(err, "fail to get domains list")
+	}
 
-		for _, domain := range domains {
-			fmt.Println(domain.Name)
-		}
+	for _, domain := range domains {
+		fmt.Println(domain.Name)
 	}
 
 	return nil

--- a/cmd/autocomplete/log_drains_remove.go
+++ b/cmd/autocomplete/log_drains_remove.go
@@ -1,0 +1,30 @@
+package autocomplete
+
+import (
+	"fmt"
+
+	"github.com/Scalingo/cli/config"
+	"github.com/urfave/cli"
+	"gopkg.in/errgo.v1"
+)
+
+func LogDrainsRemoveAutoComplete(c *cli.Context) error {
+	appName := CurrentAppCompletion(c)
+	if appName == "" {
+		return nil
+	}
+
+	client, err := config.ScalingoClient()
+	if err != nil {
+		return errgo.Notef(err, "fail to get Scalingo client")
+	}
+	drains, err := client.LogDrainsList(appName)
+	if err == nil {
+
+		for _, drain := range drains {
+			fmt.Println(drain.URL)
+		}
+	}
+
+	return nil
+}

--- a/cmd/autocomplete/log_drains_remove.go
+++ b/cmd/autocomplete/log_drains_remove.go
@@ -19,11 +19,12 @@ func LogDrainsRemoveAutoComplete(c *cli.Context) error {
 		return errgo.Notef(err, "fail to get Scalingo client")
 	}
 	drains, err := client.LogDrainsList(appName)
-	if err == nil {
+	if err != nil {
+		return errgo.Notef(err, "fail to get log drains list")
+	}
 
-		for _, drain := range drains {
-			fmt.Println(drain.URL)
-		}
+	for _, drain := range drains {
+		fmt.Println(drain.URL)
 	}
 
 	return nil

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -221,6 +221,7 @@ var (
 		// Log drains
 		logDrainsAddCommand,
 		logDrainsListCommand,
+		logDrainsRemoveCommand,
 
 		gitSetup,
 		gitShow,

--- a/cmd/log_drains.go
+++ b/cmd/log_drains.go
@@ -18,7 +18,7 @@ var (
 
 	$ scalingo --app my-app log-drains
 
-	# See also commands 'log-drains-add'`,
+	# See also commands 'log-drains-add', 'log-drains-remove'`,
 
 		Action: func(c *cli.Context) {
 			currentApp := appdetect.CurrentApp(c)
@@ -59,7 +59,7 @@ var (
 		$ scalingo --app my-app log-drains-add --type syslog --host custom.logstash.com --port 12345
 		$ scalingo --app my-app log-drains-add --type elk --url https://my-user:123456789abcdef@logstash-app-name.osc-fr1.scalingo.io
 
-	# See also commands 'log-drains'`,
+	# See also commands 'log-drains', 'log-drains-remove'`,
 
 		Action: func(c *cli.Context) {
 			currentApp := appdetect.CurrentApp(c)
@@ -78,6 +78,36 @@ var (
 		},
 		BashComplete: func(c *cli.Context) {
 			autocomplete.CmdFlagsAutoComplete(c, "log-drains")
+		},
+	}
+
+	logDrainsRemoveCommand = cli.Command{
+		Name:     "log-drains-remove",
+		Category: "Log drains",
+		Flags:    []cli.Flag{appFlag},
+		Usage:    "Remove a log drain from an application",
+		Description: `Remove a log drain from an application:
+
+	$ scalingo --app my-app log-drains-remove syslog://custom.logstash.com:12345
+
+	# See also commands 'log-drains-add', 'log-drains' and 'log-drains'`,
+
+		Action: func(c *cli.Context) {
+			currentApp := appdetect.CurrentApp(c)
+			var err error
+			if len(c.Args()) == 1 {
+				err = log_drains.Remove(currentApp, c.Args()[0])
+			} else {
+				cli.ShowCommandHelp(c, "log-drains-remove")
+			}
+
+			if err != nil {
+				errorQuit(err)
+			}
+		},
+		BashComplete: func(c *cli.Context) {
+			autocomplete.CmdFlagsAutoComplete(c, "log-drains-remove")
+			autocomplete.LogDrainsRemoveAutoComplete(c)
 		},
 	}
 )

--- a/cmd/log_drains.go
+++ b/cmd/log_drains.go
@@ -90,7 +90,7 @@ var (
 
 	$ scalingo --app my-app log-drains-remove syslog://custom.logstash.com:12345
 
-	# See also commands 'log-drains-add', 'log-drains' and 'log-drains'`,
+	# See also commands 'log-drains-add', 'log-drains'`,
 
 		Action: func(c *cli.Context) {
 			currentApp := appdetect.CurrentApp(c)

--- a/log_drains/remove.go
+++ b/log_drains/remove.go
@@ -1,0 +1,37 @@
+package log_drains
+
+import (
+	"github.com/Scalingo/cli/config"
+	"github.com/Scalingo/cli/io"
+	"github.com/Scalingo/go-scalingo"
+	"gopkg.in/errgo.v1"
+)
+
+func Remove(app string, URL string) error {
+	c, err := config.ScalingoClient()
+	if err != nil {
+		return errgo.Notef(err, "fail to get Scalingo client")
+	}
+
+	err = c.LogDrainRemove(app, URL)
+	if err != nil {
+		return errgo.Mask(err)
+	}
+
+	io.Status("The log drain:", URL, "has been deleted")
+	return nil
+}
+
+func findLogDrainsBeforeRemove(c *scalingo.Client, app string, URL string) (scalingo.LogDrain, error) {
+	drains, err := c.LogDrainsList(app)
+	if err != nil {
+		return scalingo.LogDrain{}, errgo.Mask(err)
+	}
+
+	for _, d := range drains {
+		if d.URL == URL {
+			return d, nil
+		}
+	}
+	return scalingo.LogDrain{}, errgo.New("There is no such log drain, please ensure you've added it correctly.")
+}

--- a/log_drains/remove.go
+++ b/log_drains/remove.go
@@ -3,7 +3,6 @@ package log_drains
 import (
 	"github.com/Scalingo/cli/config"
 	"github.com/Scalingo/cli/io"
-	"github.com/Scalingo/go-scalingo"
 	"gopkg.in/errgo.v1"
 )
 
@@ -20,18 +19,4 @@ func Remove(app string, URL string) error {
 
 	io.Status("The log drain:", URL, "has been deleted")
 	return nil
-}
-
-func findLogDrainsBeforeRemove(c *scalingo.Client, app string, URL string) (scalingo.LogDrain, error) {
-	drains, err := c.LogDrainsList(app)
-	if err != nil {
-		return scalingo.LogDrain{}, errgo.Mask(err)
-	}
-
-	for _, d := range drains {
-		if d.URL == URL {
-			return d, nil
-		}
-	}
-	return scalingo.LogDrain{}, errgo.New("There is no such log drain, please ensure you've added it correctly.")
 }

--- a/log_drains/remove.go
+++ b/log_drains/remove.go
@@ -9,12 +9,12 @@ import (
 func Remove(app string, URL string) error {
 	c, err := config.ScalingoClient()
 	if err != nil {
-		return errgo.Notef(err, "fail to get Scalingo client")
+		return errgo.Notef(err, "fail to get Scalingo client to remove a log drain from the application")
 	}
 
 	err = c.LogDrainRemove(app, URL)
 	if err != nil {
-		return errgo.Mask(err)
+		return errgo.Notef(err, "fail to remove the log drain from the application")
 	}
 
 	io.Status("The log drain:", URL, "has been deleted")

--- a/vendor/github.com/Scalingo/go-scalingo/log_drains.go
+++ b/vendor/github.com/Scalingo/go-scalingo/log_drains.go
@@ -69,8 +69,7 @@ func (c *Client) LogDrainAdd(app string, params LogDrainAddParams) (*LogDrainRes
 }
 
 func (c *Client) LogDrainRemove(app, URL string) error {
-	payload := make(map[string]string)
-	payload = map[string]string{
+	payload := map[string]string{
 		"url": URL,
 	}
 

--- a/vendor/github.com/Scalingo/go-scalingo/log_drains.go
+++ b/vendor/github.com/Scalingo/go-scalingo/log_drains.go
@@ -25,10 +25,6 @@ type LogDrain struct {
 	DrainRegion string `json:"drain_region"`
 }
 
-type logDrainReq struct {
-	Drain LogDrain `json:"drain"`
-}
-
 type LogDrainRes struct {
 	Drain LogDrain `json:"drain"`
 }
@@ -73,7 +69,6 @@ func (c *Client) LogDrainAdd(app string, params LogDrainAddParams) (*LogDrainRes
 }
 
 func (c *Client) LogDrainRemove(app, URL string) error {
-	var logDrainRes LogDrainRes
 	payload := make(map[string]string)
 	payload = map[string]string{
 		"url": URL,
@@ -82,11 +77,11 @@ func (c *Client) LogDrainRemove(app, URL string) error {
 	req := &httpclient.APIRequest{
 		Method:   "DELETE",
 		Endpoint: "/apps/" + app + "/log_drains",
-		Expected: httpclient.Statuses{http.StatusOK},
+		Expected: httpclient.Statuses{http.StatusNoContent},
 		Params:   payload,
 	}
 
-	err := c.ScalingoAPI().DoRequest(req, &logDrainRes)
+	err := c.ScalingoAPI().DoRequest(req, nil)
 	if err != nil {
 		return errgo.Notef(err, "fail to delete log drain")
 	}

--- a/vendor/github.com/Scalingo/go-scalingo/version.go
+++ b/vendor/github.com/Scalingo/go-scalingo/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "4.5.2"
+var Version = "4.5.3"


### PR DESCRIPTION
Add remove command

Example:
```bash
$ scalingo log-drains-remove --app sample-go-martini tcp+tls://logs.papertrailapp.com:12345
-----> The log drain: tcp+tls://logs.papertrailapp.com:12345 has been deleted
```

Fix #554 