### PR TITLE
Update go-scalingo from 4.5.3 to 4.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### To be Released
 
+* Fix infinite recursion on some events with `scalingo timeline` [#570](#570)
+* Fix log drain response parsing [#570](#570)
+
 ### 1.18.0
 
 * Add log drains list command

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,7 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  digest = "1:08eece729c1bef63ba65ac49a2dda812a07c69f489178917c6fe227f8d89301e"
+  digest = "1:25be3885f507b86c90be01f48427f3b92556cab05ad4553abab5cdeda228cf25"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -37,8 +37,8 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "69d49c22431d4655ab091eeb3e527de5413e67e6"
-  version = "v4.5.3"
+  revision = "c05f01e0fe581d97bc77fb6b7aedc328715cd860"
+  version = "v4.5.5"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/README.md
+++ b/README.md
@@ -269,6 +269,11 @@ git cherry-pick -m 1 <commit ID number 2>
 ...
 git cherry-pick -m 1 <commit ID number X>
 git push --set-upstream origin v1.18.0
+```
+
+### Tag the New Release
+
+```bash
 git tag 1.18.0
 git push --tags
 ```
@@ -282,7 +287,7 @@ Build the new version for all platforms with:
 ```
 
 The script asks you for a Rollbar token available in the shared keychain under
-the "Rollbar CLI Token" note.
+the "CLI Rollbar Token" note.
 
 Tag and release a new version on GitHub
 [here](https://github.com/Scalingo/cli/releases/new). Attach the zip archives

--- a/vendor/github.com/Scalingo/go-scalingo/events_structs.go
+++ b/vendor/github.com/Scalingo/go-scalingo/events_structs.go
@@ -222,7 +222,7 @@ func (ev *EventRestartType) Who() string {
 	if ev.TypeData.AddonName != "" {
 		return fmt.Sprintf("Addon %s", ev.TypeData.AddonName)
 	} else {
-		return ev.Who()
+		return ev.Event.Who()
 	}
 }
 
@@ -600,7 +600,7 @@ func (ev *EventUpgradeDatabaseType) Who() string {
 	if ev.TypeData.AddonName != "" {
 		return fmt.Sprintf("Addon %s", ev.TypeData.AddonName)
 	} else {
-		return ev.Who()
+		return ev.Event.Who()
 	}
 }
 
@@ -622,7 +622,7 @@ func (ev *EventNewVariableType) Who() string {
 	if ev.TypeData.AddonName != "" {
 		return fmt.Sprintf("Addon %s", ev.TypeData.AddonName)
 	} else {
-		return ev.Who()
+		return ev.Event.Who()
 	}
 }
 
@@ -679,7 +679,7 @@ func (ev *EventEditVariableType) Who() string {
 	if ev.TypeData.AddonName != "" {
 		return fmt.Sprintf("Addon %s", ev.TypeData.AddonName)
 	} else {
-		return ev.Who()
+		return ev.Event.Who()
 	}
 }
 

--- a/vendor/github.com/Scalingo/go-scalingo/log_drains.go
+++ b/vendor/github.com/Scalingo/go-scalingo/log_drains.go
@@ -29,13 +29,17 @@ type LogDrainRes struct {
 	Drain LogDrain `json:"drain"`
 }
 
+type LogDrainsRes struct {
+	Drains []LogDrain `json:"drains"`
+}
+
 func (c *Client) LogDrainsList(app string) ([]LogDrain, error) {
-	var logDrainsRes []LogDrain
+	var logDrainsRes LogDrainsRes
 	err := c.ScalingoAPI().SubresourceList("apps", app, "log_drains", nil, &logDrainsRes)
 	if err != nil {
 		return nil, errgo.Notef(err, "fail to list the log drains")
 	}
-	return logDrainsRes, nil
+	return logDrainsRes.Drains, nil
 }
 
 type LogDrainAddParams struct {

--- a/vendor/github.com/Scalingo/go-scalingo/version.go
+++ b/vendor/github.com/Scalingo/go-scalingo/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "4.5.3"
+var Version = "4.5.5"


### PR DESCRIPTION
We need this PR (https://github.com/Scalingo/go-scalingo/pull/169) for the log
drain...

This PR also fixes #569