### PR TITLE
add log drain to an addon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### To be Released
 
+* Add a log drain to an addon
+  [#575](https://github.com/Scalingo/cli/pull/575)
+  [go-scalingo #174](https://github.com/Scalingo/go-scalingo/pull/174)
 * Add list log drains by addons command
   [#572](https://github.com/Scalingo/cli/pull/572)
   [go-scalingo #172](https://github.com/Scalingo/go-scalingo/pull/172)

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,8 +26,8 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  branch = "feature/cli/571/add_log_drain_to_DB"
-  digest = "1:e3c86ac33bc7167673e0b008c77f1532041c3d4d8f9220cc16507207a593e549"
+  branch = "master"
+  digest = "1:a10a485205ac33a1bc4d1f8b9f4ddfca83e494cd48be940b7ece1274b402ed86"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -38,7 +38,7 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "720566bd8ef58c0f43d66c95232de53e1d84c311"
+  revision = "4840469e6e57825874f1f1d4ceeb7844ad1b46d0"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,8 +26,7 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  branch = "master"
-  digest = "1:a10a485205ac33a1bc4d1f8b9f4ddfca83e494cd48be940b7ece1274b402ed86"
+  digest = "1:d58a2d159db515d94824ee99685cb65571e431bf988b638d31de4652866c6094"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -38,7 +37,8 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "4840469e6e57825874f1f1d4ceeb7844ad1b46d0"
+  revision = "5af0bef7605dbe28f7c7eafd6cfc27263c9e16d8"
+  version = "v4.5.7"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,8 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  digest = "1:0806bc0c73681e19e002457047953c2caf8d9bb4c91c2fe23cc65caa175d3b20"
+  branch = "feature/cli/571/add_log_drain_to_DB"
+  digest = "1:e3c86ac33bc7167673e0b008c77f1532041c3d4d8f9220cc16507207a593e549"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -37,8 +38,7 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "a25f43c862e20204f7e4dcb1484d1d909a7cef27"
-  version = "v4.5.6"
+  revision = "720566bd8ef58c0f43d66c95232de53e1d84c311"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/Scalingo/go-scalingo"
-  branch = "master"
+  version = "^4"
 
 [[constraint]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/Scalingo/go-scalingo"
-  branch = "feature/cli/571/add_log_drain_to_DB"
+  branch = "master"
 
 [[constraint]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/Scalingo/go-scalingo"
-  version = "^4"
+  branch = "feature/cli/571/add_log_drain_to_DB"
 
 [[constraint]]
   branch = "master"

--- a/cmd/log_drains.go
+++ b/cmd/log_drains.go
@@ -61,6 +61,8 @@ var (
 		Category: "Log drains",
 		Usage:    "Add a log drain to an application",
 		Flags: []cli.Flag{appFlag,
+			addonFlag,
+			cli.BoolFlag{Name: "with-addons", Usage: "add the log drains of all addons"},
 			cli.StringFlag{Name: "type", Usage: "Communication protocol", Required: true},
 			cli.StringFlag{Name: "url", Usage: "URL of self hosted ELK"},
 			cli.StringFlag{Name: "host", Usage: "Host of logs management service"},
@@ -78,19 +80,39 @@ var (
 		$ scalingo --app my-app log-drains-add --type syslog --host custom.logstash.com --port 12345
 		$ scalingo --app my-app log-drains-add --type elk --url https://my-user:123456789abcdef@logstash-app-name.osc-fr1.scalingo.io
 
+	Add a log drain to an addon:
+
+		Use the parameter: "--addon <addon_uuid>" to your add commands to add a log drain to a specific addon
+		Use the parameter: "--with-addons" to list log drains of all addons connected to the application
+
+	Examples:
+		$ scalingo --app my-app --addon ad-3c2f8c81-99bd-4667-9791-466799bd4667 log-drains-add --type datadog --token 123456789abcdef --drain-region eu-west-2
+		$ scalingo --app my-app --with-addons log-drains-add --type datadog --token 123456789abcdef --drain-region eu-west-2
+
 	# See also commands 'log-drains', 'log-drains-remove'`,
 
 		Action: func(c *cli.Context) {
 			currentApp := appdetect.CurrentApp(c)
 
-			err := log_drains.Add(currentApp, scalingo.LogDrainAddParams{
-				Type:        c.String("type"),
-				URL:         c.String("url"),
-				Host:        c.String("host"),
-				Port:        c.String("port"),
-				Token:       c.String("token"),
-				DrainRegion: c.String("drain-region"),
-			})
+			var addonID string
+			if c.GlobalString("addon") != "<addon_id>" {
+				addonID = c.GlobalString("addon")
+			} else if c.String("addon") != "<addon_id>" {
+				addonID = c.String("addon")
+			}
+
+			err := log_drains.Add(currentApp, log_drains.ListAddonOpts{
+				WithAddons: c.Bool("with-addons"),
+				AddonID:    addonID,
+			},
+				scalingo.LogDrainAddParams{
+					Type:        c.String("type"),
+					URL:         c.String("url"),
+					Host:        c.String("host"),
+					Port:        c.String("port"),
+					Token:       c.String("token"),
+					DrainRegion: c.String("drain-region"),
+				})
 			if err != nil {
 				errorQuit(err)
 			}

--- a/cmd/log_drains.go
+++ b/cmd/log_drains.go
@@ -83,7 +83,9 @@ var (
 	Add a log drain to an addon:
 
 		Use the parameter: "--addon <addon_uuid>" to your add commands to add a log drain to a specific addon
-		Use the parameter: "--with-addons" to list log drains of all addons connected to the application
+		Use the parameter: "--with-addons" to list log drains of all addons connected to the application.
+
+		Warning: At the moment, all addons except databases cannot throw logs.
 
 	Examples:
 		$ scalingo --app my-app --addon ad-3c2f8c81-99bd-4667-9791-466799bd4667 log-drains-add --type datadog --token 123456789abcdef --drain-region eu-west-2

--- a/cmd/log_drains.go
+++ b/cmd/log_drains.go
@@ -62,7 +62,7 @@ var (
 		Usage:    "Add a log drain to an application",
 		Flags: []cli.Flag{appFlag,
 			addonFlag,
-			cli.BoolFlag{Name: "with-addons", Usage: "add the log drains of all addons"},
+			cli.BoolFlag{Name: "with-addons", Usage: "also add the log drains to all addons"},
 			cli.StringFlag{Name: "type", Usage: "Communication protocol", Required: true},
 			cli.StringFlag{Name: "url", Usage: "URL of self hosted ELK"},
 			cli.StringFlag{Name: "host", Usage: "Host of logs management service"},
@@ -82,10 +82,10 @@ var (
 
 	Add a log drain to an addon:
 
-		Use the parameter: "--addon <addon_uuid>" to your add commands to add a log drain to a specific addon
+		Use the parameter: "--addon <addon_uuid>" to your add command to add a log drain to a specific addon
 		Use the parameter: "--with-addons" to list log drains of all addons connected to the application.
 
-		Warning: At the moment, all addons except databases cannot throw logs.
+		Warning: At the moment, only databases addons are able to throw logs.
 
 	Examples:
 		$ scalingo --app my-app --addon ad-3c2f8c81-99bd-4667-9791-466799bd4667 log-drains-add --type datadog --token 123456789abcdef --drain-region eu-west-2
@@ -103,10 +103,11 @@ var (
 				addonID = c.String("addon")
 			}
 
-			err := log_drains.Add(currentApp, log_drains.ListAddonOpts{
-				WithAddons: c.Bool("with-addons"),
-				AddonID:    addonID,
-			},
+			err := log_drains.Add(currentApp,
+				log_drains.AddAddonOpts{
+					WithAddons: c.Bool("with-addons"),
+					AddonID:    addonID,
+				},
 				scalingo.LogDrainAddParams{
 					Type:        c.String("type"),
 					URL:         c.String("url"),

--- a/cmd/log_drains.go
+++ b/cmd/log_drains.go
@@ -103,18 +103,23 @@ var (
 				addonID = c.String("addon")
 			}
 
+			if addonID != "" && c.Bool("with-addons") {
+				cli.ShowCommandHelp(c, "log-drains-add")
+				return
+			}
+
 			err := log_drains.Add(currentApp,
-				log_drains.AddAddonOpts{
+				log_drains.AddDrainOpts{
 					WithAddons: c.Bool("with-addons"),
 					AddonID:    addonID,
-				},
-				scalingo.LogDrainAddParams{
-					Type:        c.String("type"),
-					URL:         c.String("url"),
-					Host:        c.String("host"),
-					Port:        c.String("port"),
-					Token:       c.String("token"),
-					DrainRegion: c.String("drain-region"),
+					Params: scalingo.LogDrainAddParams{
+						Type:        c.String("type"),
+						URL:         c.String("url"),
+						Host:        c.String("host"),
+						Port:        c.String("port"),
+						Token:       c.String("token"),
+						DrainRegion: c.String("drain-region"),
+					},
 				})
 			if err != nil {
 				errorQuit(err)

--- a/log_drains/add.go
+++ b/log_drains/add.go
@@ -17,7 +17,6 @@ func Add(app string, opts ListAddonOpts, params scalingo.LogDrainAddParams) erro
 		d, err := c.LogDrainAdd(app, params)
 		if err != nil {
 			io.Status("fail to add drain to", "'"+app+"'", "application:\n\t", err)
-			// return errgo.Notef(err, "fail to add drain to the application")
 		} else {
 			io.Status("Log drain", d.Drain.URL, "has been added to the application", app)
 		}
@@ -34,7 +33,6 @@ func Add(app string, opts ListAddonOpts, params scalingo.LogDrainAddParams) erro
 			d, err := c.LogDrainAddonAdd(app, addon.ID, params)
 			if err != nil {
 				io.Status("fail to add drain to", "'"+addon.AddonProvider.Name+"'", "addon:\n\t", err)
-				// return errgo.Notef(err, "fail to add drain to an addon")
 			} else {
 				io.Status("Log drain", d.Drain.URL, "has been added to the addon", addon.AddonProvider.Name)
 			}

--- a/log_drains/add.go
+++ b/log_drains/add.go
@@ -7,7 +7,12 @@ import (
 	"gopkg.in/errgo.v1"
 )
 
-func Add(app string, opts ListAddonOpts, params scalingo.LogDrainAddParams) error {
+type AddAddonOpts struct {
+	WithAddons bool
+	AddonID    string
+}
+
+func Add(app string, opts AddAddonOpts, params scalingo.LogDrainAddParams) error {
 	c, err := config.ScalingoClient()
 	if err != nil {
 		return errgo.Notef(err, "fail to get Scalingo client to add a log drain")
@@ -20,6 +25,9 @@ func Add(app string, opts ListAddonOpts, params scalingo.LogDrainAddParams) erro
 		} else {
 			io.Status("Log drain", d.Drain.URL, "has been added to the application", app)
 		}
+	}
+	if !opts.WithAddons && opts.AddonID == "" {
+		return nil
 	}
 
 	addons, err := c.AddonsList(app)

--- a/log_drains/add.go
+++ b/log_drains/add.go
@@ -7,19 +7,20 @@ import (
 	"gopkg.in/errgo.v1"
 )
 
-type AddAddonOpts struct {
+type AddDrainOpts struct {
 	WithAddons bool
 	AddonID    string
+	Params     scalingo.LogDrainAddParams
 }
 
-func Add(app string, opts AddAddonOpts, params scalingo.LogDrainAddParams) error {
+func Add(app string, opts AddDrainOpts) error {
 	c, err := config.ScalingoClient()
 	if err != nil {
 		return errgo.Notef(err, "fail to get Scalingo client to add a log drain")
 	}
 
 	if opts.AddonID == "" || opts.WithAddons {
-		d, err := c.LogDrainAdd(app, params)
+		d, err := c.LogDrainAdd(app, opts.Params)
 		if err != nil {
 			io.Status("fail to add drain to", "'"+app+"'", "application:\n\t", err)
 		} else {
@@ -30,15 +31,20 @@ func Add(app string, opts AddAddonOpts, params scalingo.LogDrainAddParams) error
 		return nil
 	}
 
+	isAddonIDPresent := false
 	addons, err := c.AddonsList(app)
 	if err != nil {
 		return errgo.Notef(err, "fail to list addons")
 	}
 
 	for _, addon := range addons {
+		if opts.AddonID == addon.ID {
+			isAddonIDPresent = true
+		}
+
 		if opts.AddonID == addon.ID || opts.WithAddons {
 			// TODO(pc): do we need to test if the addon is a DB ?
-			d, err := c.LogDrainAddonAdd(app, addon.ID, params)
+			d, err := c.LogDrainAddonAdd(app, addon.ID, opts.Params)
 			if err != nil {
 				io.Status("fail to add drain to", "'"+addon.AddonProvider.Name+"'", "addon:\n\t", err)
 			} else {
@@ -49,6 +55,9 @@ func Add(app string, opts AddAddonOpts, params scalingo.LogDrainAddParams) error
 				return nil
 			}
 		}
+	}
+	if !isAddonIDPresent && opts.AddonID != "" {
+		return errgo.Notef(nil, "fail to add addon: addon_uuid doesn't exist for this application")
 	}
 	return nil
 }

--- a/log_drains/add.go
+++ b/log_drains/add.go
@@ -7,17 +7,42 @@ import (
 	"gopkg.in/errgo.v1"
 )
 
-func Add(app string, params scalingo.LogDrainAddParams) error {
+func Add(app string, opts ListAddonOpts, params scalingo.LogDrainAddParams) error {
 	c, err := config.ScalingoClient()
 	if err != nil {
 		return errgo.Notef(err, "fail to get Scalingo client to add a log drain")
 	}
 
-	d, err := c.LogDrainAdd(app, params)
-	if err != nil {
-		return errgo.Notef(err, "fail to add drain to the application")
+	if opts.AddonID == "" || opts.WithAddons {
+		d, err := c.LogDrainAdd(app, params)
+		if err != nil {
+			io.Status("fail to add drain to", "'"+app+"'", "application:\n\t", err)
+			// return errgo.Notef(err, "fail to add drain to the application")
+		} else {
+			io.Status("Log drain", d.Drain.URL, "has been added to the application", app)
+		}
 	}
 
-	io.Status("Log drain", d.Drain.URL, "has been added to the application", app)
+	addons, err := c.AddonsList(app)
+	if err != nil {
+		return errgo.Notef(err, "fail to list addons")
+	}
+
+	for _, addon := range addons {
+		if opts.AddonID == addon.ID || opts.WithAddons {
+			// TODO(pc): do we need to test if the addon is a DB ?
+			d, err := c.LogDrainAddonAdd(app, addon.ID, params)
+			if err != nil {
+				io.Status("fail to add drain to", "'"+addon.AddonProvider.Name+"'", "addon:\n\t", err)
+				// return errgo.Notef(err, "fail to add drain to an addon")
+			} else {
+				io.Status("Log drain", d.Drain.URL, "has been added to the addon", addon.AddonProvider.Name)
+			}
+
+			if !opts.WithAddons {
+				return nil
+			}
+		}
+	}
 	return nil
 }

--- a/vendor/github.com/Scalingo/go-scalingo/log_drains.go
+++ b/vendor/github.com/Scalingo/go-scalingo/log_drains.go
@@ -119,7 +119,7 @@ func (c *Client) LogDrainAddonAdd(app string, addonID string, params LogDrainAdd
 
 	err := c.ScalingoAPI().SubresourceAdd("apps", app, "addons/"+addonID+"/log_drains", payload, &logDrainRes)
 	if err != nil {
-		return &logDrainRes, errgo.Notef(err, "fail to add log drain to the addon %s", addonID)
+		return nil, errgo.Notef(err, "fail to add log drain to the addon %s", addonID)
 	}
 
 	return &logDrainRes, nil

--- a/vendor/github.com/Scalingo/go-scalingo/log_drains.go
+++ b/vendor/github.com/Scalingo/go-scalingo/log_drains.go
@@ -12,6 +12,7 @@ type LogDrainsService interface {
 	LogDrainAdd(app string, params LogDrainAddParams) (*LogDrainRes, error)
 	LogDrainRemove(app, URL string) error
 	LogDrainsAddonList(app string, addonID string) (LogDrainsRes, error)
+	LogDrainAddonAdd(app string, addonID string, params LogDrainAddParams) (*LogDrainRes, error)
 }
 
 var _ LogDrainsService = (*Client)(nil)
@@ -101,4 +102,25 @@ func (c *Client) LogDrainRemove(app, URL string) error {
 	}
 
 	return nil
+}
+
+func (c *Client) LogDrainAddonAdd(app string, addonID string, params LogDrainAddParams) (*LogDrainRes, error) {
+	var logDrainRes LogDrainRes
+	payload := LogDrainRes{
+		Drain: LogDrain{
+			Type:        params.Type,
+			URL:         params.URL,
+			Host:        params.Host,
+			Port:        params.Port,
+			Token:       params.Token,
+			DrainRegion: params.DrainRegion,
+		},
+	}
+
+	err := c.ScalingoAPI().SubresourceAdd("apps", app, "addons/"+addonID+"/log_drains", payload, &logDrainRes)
+	if err != nil {
+		return &logDrainRes, errgo.Notef(err, "fail to add log drain to the addon %s", addonID)
+	}
+
+	return &logDrainRes, nil
 }

--- a/vendor/github.com/Scalingo/go-scalingo/version.go
+++ b/vendor/github.com/Scalingo/go-scalingo/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "4.5.6"
+var Version = "4.5.7"


### PR DESCRIPTION
User will provide `addon <addon_uuid>` to the `log-drains` command.
Example:
```bash
$ scalingo --app my-app --addon ad-1234567-1123 log-drains-add \
--type papertrail --host logs.papertrailapp.com --port 10303
```


Or add a log drains to all addons linked to the app:

```bash
$ scalingo --app my-app --with-addon log-drains-add \
--type papertrail --host logs.papertrailapp.com --port 10303
```
Fix #571