### PR TITLE
Remove log drains from db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### To be Released
 
+* Remove a log drain from an addon
+  [#577](https://github.com/Scalingo/cli/pull/577)
+  [go-scalingo #175](https://github.com/Scalingo/go-scalingo/pull/175)
 * Add a log drain to an addon
   [#575](https://github.com/Scalingo/cli/pull/575)
   [go-scalingo #174](https://github.com/Scalingo/go-scalingo/pull/174)

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,7 +26,8 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  digest = "1:d58a2d159db515d94824ee99685cb65571e431bf988b638d31de4652866c6094"
+  branch = "feature/cli/576/remove_log_drain_from_db"
+  digest = "1:23498d03e2a2117346d5def9486410790b626e5505b7d2ca51fa2e628f412510"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -37,8 +38,7 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "5af0bef7605dbe28f7c7eafd6cfc27263c9e16d8"
-  version = "v4.5.7"
+  revision = "902f939808781aa3aeb27319f0f9895f0c71bb7b"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,7 +27,7 @@
 
 [[projects]]
   branch = "feature/cli/576/remove_log_drain_from_db"
-  digest = "1:23498d03e2a2117346d5def9486410790b626e5505b7d2ca51fa2e628f412510"
+  digest = "1:15a57f7ecf2be15fe29f4bebc4128a9105290c237b20f39120afbc5e695e40fc"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -38,7 +38,7 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "902f939808781aa3aeb27319f0f9895f0c71bb7b"
+  revision = "2f8650a862e9a2083597cf874a733cde12473321"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -26,8 +26,7 @@
   revision = "8eb48cc6f27eafda8e3a9627edba494a1d229a01"
 
 [[projects]]
-  branch = "feature/cli/576/remove_log_drain_from_db"
-  digest = "1:15a57f7ecf2be15fe29f4bebc4128a9105290c237b20f39120afbc5e695e40fc"
+  digest = "1:dcd5c59297daac978a4a050a585c29b28c745df3d0d8f12e3d4d3689f7918580"
   name = "github.com/Scalingo/go-scalingo"
   packages = [
     ".",
@@ -38,7 +37,8 @@
     "io",
   ]
   pruneopts = "NUT"
-  revision = "2f8650a862e9a2083597cf874a733cde12473321"
+  revision = "fec0faece36ffe70f16bca9834b1894e833e78a2"
+  version = "v4.5.8"
 
 [[projects]]
   digest = "1:ab7f2d565135ccc3b35eb2427819fbca0501d582eba5091e684275022d3ff3ba"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/Scalingo/go-scalingo"
-  branch = "feature/cli/576/remove_log_drain_from_db"
+  version = "^4"
 
 [[constraint]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [[constraint]]
   name = "github.com/Scalingo/go-scalingo"
-  version = "^4"
+  branch = "feature/cli/576/remove_log_drain_from_db"
 
 [[constraint]]
   branch = "master"

--- a/cmd/log_drains.go
+++ b/cmd/log_drains.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/AlecAivazis/survey"
 	"github.com/Scalingo/cli/appdetect"
 	"github.com/Scalingo/cli/cmd/autocomplete"
 	"github.com/Scalingo/cli/log_drains"
@@ -156,7 +159,6 @@ var (
 	# See also commands 'log-drains-add', 'log-drains'`,
 
 		Action: func(c *cli.Context) {
-			// TODO: survey
 			currentApp := appdetect.CurrentApp(c)
 
 			var addonID string
@@ -164,6 +166,19 @@ var (
 				addonID = c.GlobalString("addon")
 			} else if c.String("addon") != "<addon_id>" {
 				addonID = c.String("addon")
+			}
+
+			if addonID != "" && c.Bool("only-app") {
+				cli.ShowCommandHelp(c, "log-drains-remove")
+				return
+			}
+
+			if addonID == "" && !c.Bool("only-app") {
+				result := askContinue("This operation will delete the log drain " + c.Args()[0] + " for the application and all addons connected to this application")
+				if !result {
+					fmt.Println("Aborted")
+					return
+				}
 			}
 
 			var err error
@@ -187,3 +202,12 @@ var (
 		},
 	}
 )
+
+func askContinue(message string) bool {
+	result := false
+	prompt := &survey.Confirm{
+		Message: message + "\n\tContinue ?",
+	}
+	survey.AskOne(prompt, &result, nil)
+	return result
+}

--- a/cmd/log_drains.go
+++ b/cmd/log_drains.go
@@ -22,8 +22,8 @@ var (
 		Usage: "List the log drains of an application",
 		Description: `List all the log drains of an application:
 
-	Use the parameter: "--addon <addon_uuid>" to list log drains of a specific addon
-	Use the parameter: "--with-addons" to list log drains of all addons connected to the application
+	Use the parameter "--addon <addon_uuid>" to list log drains of a specific addon
+	Use the parameter "--with-addons" to list log drains of all addons connected to the application
 
 	Examples:
 		$ scalingo --app my-app log-drains
@@ -31,7 +31,6 @@ var (
 		$ scalingo --app my-app log-drains --with-addons
 
 	# See also commands 'log-drains-add', 'log-drains-remove'`,
-
 		Action: func(c *cli.Context) {
 			currentApp := appdetect.CurrentApp(c)
 			if len(c.Args()) != 0 {
@@ -85,8 +84,8 @@ var (
 
 	Add a log drain to an addon:
 
-		Use the parameter: "--addon <addon_uuid>" to your add command to add a log drain to a specific addon
-		Use the parameter: "--with-addons" to list log drains of all addons connected to the application.
+		Use the parameter "--addon <addon_uuid>" to your add command to add a log drain to a specific addon
+		Use the parameter "--with-addons" to list log drains of all addons connected to the application.
 
 		Warning: At the moment, only databases addons are able to throw logs.
 
@@ -141,19 +140,19 @@ var (
 			addonFlag,
 			cli.BoolFlag{Name: "only-app", Usage: "remove the log drains for the application only"},
 		},
-		Usage: "Remove a log drain from an application and addons",
-		Description: `Remove a log drain from an application and all addons connected to the application:
+		Usage: "Remove a log drain from an application and its associated addons",
+		Description: `Remove a log drain from an application and all its addons:
 
 		$ scalingo --app my-app log-drains-remove syslog://custom.logstash.com:12345
 
 	Remove a log drain from a specific addon:
-		Use the parameter: "--addon <addon_uuid>" to your remove commands to remove a log drain from a specific addon
+		Use the parameter "--addon <addon_uuid>" to remove a log drain from a specific addon
 
 		$ scalingo --app my-app --addon ad-3c2f8c81-99bd-4667-9791-466799bd4667 log-drains-remove syslog://custom.logstash.com:12345
 
 	Remove a log drain only for the application:
-		Use the parameter: "--only-app" to your remove commands to remove log drain only from the application
-		
+		Use the parameter "--only-app" to remove a log drain only from the application
+
 		$ scalingo --app my-app --only-app log-drains-remove syslog://custom.logstash.com:12345
 
 	# See also commands 'log-drains-add', 'log-drains'`,
@@ -173,12 +172,21 @@ var (
 				return
 			}
 
+			message := "This operation will delete the log drain " + c.Args()[0]
 			if addonID == "" && !c.Bool("only-app") {
-				result := askContinue("This operation will delete the log drain " + c.Args()[0] + " for the application and all addons connected to this application")
-				if !result {
-					fmt.Println("Aborted")
-					return
-				}
+				// addons + app
+				message += " for the application and all its addons"
+			} else if addonID != "" && !c.Bool("only-app") {
+				// addon only
+				message += " for the addon " + addonID
+			} else {
+				// app only
+				message += " for the application " + currentApp
+			}
+			result := askContinue(message)
+			if !result {
+				fmt.Println("Aborted")
+				return
 			}
 
 			var err error
@@ -206,7 +214,7 @@ var (
 func askContinue(message string) bool {
 	result := false
 	prompt := &survey.Confirm{
-		Message: message + "\n\tContinue ?",
+		Message: message + "\n\tConfirm deletion ?",
 	}
 	survey.AskOne(prompt, &result, nil)
 	return result

--- a/log_drains/remove.go
+++ b/log_drains/remove.go
@@ -6,17 +6,48 @@ import (
 	"gopkg.in/errgo.v1"
 )
 
-func Remove(app string, URL string) error {
+type RemoveAddonOpts struct {
+	WithAddons bool
+	AddonID    string
+	OnlyApp    bool
+	URL        string
+}
+
+func Remove(app string, opts RemoveAddonOpts) error {
 	c, err := config.ScalingoClient()
 	if err != nil {
 		return errgo.Notef(err, "fail to get Scalingo client to remove a log drain from the application")
 	}
 
-	err = c.LogDrainRemove(app, URL)
-	if err != nil {
-		return errgo.Notef(err, "fail to remove the log drain from the application")
+	if opts.OnlyApp {
+		// app only
+		err = c.LogDrainRemove(app, opts.URL)
+		if err != nil {
+			return errgo.Notef(err, "fail to remove the log drain from the application")
+		}
+	} else if opts.AddonID != "" {
+		// addons only
+		err := c.LogDrainAddonRemove(app, opts.AddonID, opts.URL)
+		if err != nil {
+			return errgo.Notef(err, "fail to remove the log drain from the addon %s", opts.AddonID)
+		}
+	} else {
+		// app + addons
+		addons, err := c.AddonsList(app)
+		if err != nil {
+			return errgo.Notef(err, "fail to list addons")
+		}
+
+		for _, addon := range addons {
+			err := c.LogDrainAddonRemove(app, addon.ID, opts.URL)
+			if err != nil {
+				io.Status("fail to remove the log drain from the addon:", addon.AddonProvider.Name, "\n\t", err)
+			} else {
+				io.Status("Log drain", opts.URL, "has been deleted from the addon", addon.AddonProvider.Name)
+			}
+		}
 	}
 
-	io.Status("The log drain:", URL, "has been deleted")
+	io.Status("The log drain:", opts.URL, "has been deleted")
 	return nil
 }

--- a/log_drains/remove.go
+++ b/log_drains/remove.go
@@ -7,10 +7,9 @@ import (
 )
 
 type RemoveAddonOpts struct {
-	WithAddons bool
-	AddonID    string
-	OnlyApp    bool
-	URL        string
+	AddonID string
+	OnlyApp bool
+	URL     string
 }
 
 func Remove(app string, opts RemoveAddonOpts) error {
@@ -19,35 +18,37 @@ func Remove(app string, opts RemoveAddonOpts) error {
 		return errgo.Notef(err, "fail to get Scalingo client to remove a log drain from the application")
 	}
 
-	if opts.OnlyApp {
-		// app only
-		err = c.LogDrainRemove(app, opts.URL)
-		if err != nil {
-			return errgo.Notef(err, "fail to remove the log drain from the application")
-		}
-	} else if opts.AddonID != "" {
+	if opts.AddonID != "" {
 		// addons only
 		err := c.LogDrainAddonRemove(app, opts.AddonID, opts.URL)
 		if err != nil {
 			return errgo.Notef(err, "fail to remove the log drain from the addon %s", opts.AddonID)
 		}
+		io.Status("The log drain:", opts.URL, "has been deleted from the addon", opts.AddonID)
 	} else {
-		// app + addons
-		addons, err := c.AddonsList(app)
+		err = c.LogDrainRemove(app, opts.URL)
 		if err != nil {
-			return errgo.Notef(err, "fail to list addons")
+			io.Status("fail to remove the log drain from the application:", app, "\n\t", err)
+		} else {
+			io.Status("Log drain", opts.URL, "has been deleted from the application", app)
 		}
 
-		for _, addon := range addons {
-			err := c.LogDrainAddonRemove(app, addon.ID, opts.URL)
+		if !opts.OnlyApp {
+			addons, err := c.AddonsList(app)
 			if err != nil {
-				io.Status("fail to remove the log drain from the addon:", addon.AddonProvider.Name, "\n\t", err)
-			} else {
-				io.Status("Log drain", opts.URL, "has been deleted from the addon", addon.AddonProvider.Name)
+				return errgo.Notef(err, "fail to list addons")
+			}
+
+			for _, addon := range addons {
+				err := c.LogDrainAddonRemove(app, addon.ID, opts.URL)
+				if err != nil {
+					io.Status("fail to remove the log drain from the addon:", addon.AddonProvider.Name, "\n\t", err)
+				} else {
+					io.Status("Log drain", opts.URL, "has been deleted from the addon", addon.AddonProvider.Name)
+				}
 			}
 		}
 	}
 
-	io.Status("The log drain:", opts.URL, "has been deleted")
 	return nil
 }

--- a/vendor/github.com/Scalingo/go-scalingo/log_drains.go
+++ b/vendor/github.com/Scalingo/go-scalingo/log_drains.go
@@ -11,6 +11,7 @@ type LogDrainsService interface {
 	LogDrainsList(app string) ([]LogDrain, error)
 	LogDrainAdd(app string, params LogDrainAddParams) (*LogDrainRes, error)
 	LogDrainRemove(app, URL string) error
+	LogDrainAddonRemove(app, addonID string, URL string) error
 	LogDrainsAddonList(app string, addonID string) (LogDrainsRes, error)
 	LogDrainAddonAdd(app string, addonID string, params LogDrainAddParams) (*LogDrainRes, error)
 }
@@ -99,6 +100,26 @@ func (c *Client) LogDrainRemove(app, URL string) error {
 	err := c.ScalingoAPI().DoRequest(req, nil)
 	if err != nil {
 		return errgo.Notef(err, "fail to delete log drain")
+	}
+
+	return nil
+}
+
+func (c *Client) LogDrainAddonRemove(app, addonID string, URL string) error {
+	payload := map[string]string{
+		"url": URL,
+	}
+
+	req := &httpclient.APIRequest{
+		Method:   "DELETE",
+		Endpoint: "/apps/" + app + "/addons/" + addonID + "/log_drains",
+		Expected: httpclient.Statuses{http.StatusNoContent},
+		Params:   payload,
+	}
+
+	err := c.ScalingoAPI().DoRequest(req, nil)
+	if err != nil {
+		return errgo.Notef(err, "fail to delete log drain of the addon %s", addonID)
 	}
 
 	return nil

--- a/vendor/github.com/Scalingo/go-scalingo/log_drains.go
+++ b/vendor/github.com/Scalingo/go-scalingo/log_drains.go
@@ -119,7 +119,7 @@ func (c *Client) LogDrainAddonRemove(app, addonID string, URL string) error {
 
 	err := c.ScalingoAPI().DoRequest(req, nil)
 	if err != nil {
-		return errgo.Notef(err, "fail to delete log drain of the addon %s", addonID)
+		return errgo.Notef(err, "fail to delete log drain %s from the addon %s", URL, addonID)
 	}
 
 	return nil

--- a/vendor/github.com/Scalingo/go-scalingo/version.go
+++ b/vendor/github.com/Scalingo/go-scalingo/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "4.5.7"
+var Version = "4.5.8"


### PR DESCRIPTION
Command: remove a log drain from a DB (with addon uuid)

Example:
With an application `app-1` with 2 addons `` and ``
```bash
$ scalingo --app app-1 log-drains-remove tcp+tls://logs.papertrailapp.com:10303
-----> Log drain tcp+tls://logs.papertrailapp.com:10303 has been deleted from the application app-1
-----> Log drain tcp+tls://logs.papertrailapp.com:10303 has been deleted from the addon Scalingo Redis
-----> Log drain tcp+tls://logs.papertrailapp.com:10303 has been deleted from the addon Scalingo Mongo

$ scalingo --app app-1 --addon ad-1234567-1123 log-drains-remove tcp+tls://logs.papertrailapp.com:10303
-----> Log drain tcp+tls://logs.papertrailapp.com:10303 has been deleted from the addon Scalingo Redis

$ scalingo --app app-1 --only-app log-drains-remove tcp+tls://logs.papertrailapp.com:10303
-----> Log drain tcp+tls://logs.papertrailapp.com:10303 has been deleted from the application app-1
```

Fix #576 