### PR TITLE
Continue to list log drains of application even if an addon is not a database

### DIFF
--- a/cmd/log_drains.go
+++ b/cmd/log_drains.go
@@ -134,7 +134,7 @@ var (
 			}
 		},
 		BashComplete: func(c *cli.Context) {
-			autocomplete.CmdFlagsAutoComplete(c, "log-drains")
+			autocomplete.CmdFlagsAutoComplete(c, "log-drains-add")
 		},
 	}
 

--- a/log_drains/list.go
+++ b/log_drains/list.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/Scalingo/cli/config"
+	"github.com/Scalingo/cli/io"
 	"github.com/Scalingo/go-scalingo"
 	"github.com/olekukonko/tablewriter"
 	"gopkg.in/errgo.v1"
@@ -49,7 +50,7 @@ func List(app string, opts ListAddonOpts) error {
 			if opts.AddonID == addon.ID || opts.WithAddons {
 				res, err := c.LogDrainsAddonList(app, addon.ID)
 				if err != nil {
-					return errgo.Notef(err, "fail to list the log drains of an addon")
+					io.Status(err)
 				}
 				if len(res.Drains) > 0 {
 					appToPrint = append(appToPrint, printableDrains{


### PR DESCRIPTION
```bash
$ scalingo --app my-app log-drains --with-addons
-----> fail to list the log drains of the addon ad-3333333-a2a5-4136-95f2-3cd90803a333: 400 Bad Request → This addon doesn't support log drains
+-------------+----------------------------------------+
|     NAME    |                   URL                  |
+-------------+----------------------------------------+
| my-app      | tcp+tls://logs.papertrailapp.com:10303 |
| Redis       | ovh://:id@gra3.logs.ovh.com:6514       |
+-------------+----------------------------------------+

```

Fix #583