### PR TITLE
Add informative error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### To be Released
 
-* Add informative error in case of container type error
+* Add informative error in case of container type error when scaling an application
   [602](https://github.com/Scalingo/cli/pull/602)
 
 ### 1.19.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### To be Released
 
+* Add informative error in case of container type error
+  [602](https://github.com/Scalingo/cli/pull/602)
+
 ### 1.19.3
 
 * Add support for new log drain/addon log drain events

--- a/apps/scale.go
+++ b/apps/scale.go
@@ -113,7 +113,7 @@ func Scale(app string, sync bool, types []string) error {
 
 			// In case of unprocessable, format and return an clear error
 			if reqestFailedError.Code == 422 {
-				return formatContainerTypesError(c, app)
+				return formatContainerTypesError(c, app, reqestFailedError)
 			}
 
 			return errgo.Mask(err)
@@ -149,7 +149,7 @@ func Scale(app string, sync bool, types []string) error {
 	return nil
 }
 
-func formatContainerTypesError(c *scalingo.Client, app string) error {
+func formatContainerTypesError(c *scalingo.Client, app string, reqestFailedError *http.RequestFailedError) error {
 	containerTypes, err := c.AppsPs(app)
 	if err != nil {
 		return errgo.Notef(err, "Fail to get container types.")
@@ -167,7 +167,7 @@ func formatContainerTypesError(c *scalingo.Client, app string) error {
 		containerTypesName = containerTypesName + ", '" + containerType.Name + "'"
 	}
 
-	errMessage := `Containers type not found.
+	errMessage := reqestFailedError.APIError.Error() + `
 
 Your available container `
 	if len(containerTypes) > 1 {

--- a/apps/scale.go
+++ b/apps/scale.go
@@ -111,7 +111,7 @@ func Scale(app string, sync bool, types []string) error {
 		if !utils.IsPaymentRequiredAndFreeTrialExceededError(err) {
 			reqestFailedError, ok := errors.ErrgoRoot(err).(*http.RequestFailedError)
 			if !ok {
-				return errgo.Mask(err)
+				return errgo.Notef(err, "request to scale the application failed")
 			}
 
 			// In case of unprocessable, format and return a clear error


### PR DESCRIPTION
- [ ] Add a changelog entry in the section "To Be Released" of CHANGELOG.md

Now errors are printed like:

```bash
scalingo --app sample-go-martini scale M:0 Test:0
 !     An error occurred:
       * M → containers type not found
       * Test → containers type not found
       
       Your available container types are: 'web', 'other'.
       
       Example of usage:
       scalingo --app my-app scale web:2 worker:1
       scalingo --app my-app scale web:1:XL
       scalingo --app my-app scale web:+1 worker:-1
       
       Use 'scalingo scale --help' for more information

```
Related to https://github.com/Scalingo/api/pull/1799
Related to https://github.com/Scalingo/one-stop-shop/issues/191
Related to [OPSB-49]

[OPSB-49]: https://scalingo.atlassian.net/browse/OPSB-49