### PR TITLE
fix(integration-link-create): clearer error message in case of unknown repository

### DIFF
--- a/integrationlink/create.go
+++ b/integrationlink/create.go
@@ -52,13 +52,13 @@ func Create(app string, integrationType scalingo.SCMType, integrationURL string,
 
 	_, err = c.SCMRepoLinkCreate(app, params)
 	if err != nil {
-		if !utils.IsPaymentRequiredAndFreeTrialExceededError(err) {
-			return errgo.Notef(err, "fail to create the repo link")
+		if utils.IsPaymentRequiredAndFreeTrialExceededError(err) {
+			return utils.AskAndStopFreeTrial(c, func() error {
+				return Create(app, integrationType, integrationURL, params)
+			})
 		}
 
-		return utils.AskAndStopFreeTrial(c, func() error {
-			return Create(app, integrationType, integrationURL, params)
-		})
+		return errgo.Notef(err, "fail to create the repo link")
 	}
 
 	io.Statusf("Your app '%s' is linked to the repository %s.\n", app, integrationURL)


### PR DESCRIPTION
I didn't add a CHANGELOG entry, it does not seem worth it...

```
go build -o scalingo-cli ./scalingo && ./scalingo-cli -a biniou integration-link-create https://github.com/EtienneM/sample-go-martinii
 !     Fail to create SCM repository integration: the repository has not been found
 !     Check https://github.com/EtienneM/sample-go-martinii exists and you have the correct permissions
 !     https://doc.scalingo.com/platform/deployment/deploy-with-github
```

Fix #522


- [ ] Add a changelog entry in the section "To Be Released" of CHANGELOG.md