### PR TITLE
fix(ps): command needs an extra API query for web containers

### DIFF
--- a/apps/ps.go
+++ b/apps/ps.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Scalingo/cli/config"
 	"github.com/Scalingo/cli/utils"
+	"github.com/Scalingo/go-scalingo/v4"
 	"github.com/olekukonko/tablewriter"
 	"gopkg.in/errgo.v1"
 )
@@ -20,12 +21,31 @@ func Ps(app string) error {
 		return errgo.Notef(err, "fail to list the application containers")
 	}
 
+	containerTypesSlice, err := c.AppsContainerTypes(app)
+	if err != nil {
+		return errgo.Notef(err, "fail to list the application container types")
+	}
+	containerTypes := containerTypesSliceToMap(containerTypesSlice)
+
 	t := tablewriter.NewWriter(os.Stdout)
 	t.SetHeader([]string{"Name", "Status", "Command", "Size", "Created At"})
 
 	for _, container := range containers {
-		t.Append([]string{container.Label, container.State, container.Command, container.ContainerSize.HumanName, container.CreatedAt.Format(utils.TimeFormat)})
+		command := container.Command
+		if command == "" {
+			command = containerTypes[container.Type].Command
+		}
+		t.Append([]string{container.Label, container.State, command, container.ContainerSize.HumanName, container.CreatedAt.Format(utils.TimeFormat)})
 	}
 	t.Render()
 	return nil
+}
+
+// containerTypesSliceToMap takes a slice of container types, and returns a map with the index being the type name
+func containerTypesSliceToMap(containerTypesSlice []scalingo.ContainerType) map[string]scalingo.ContainerType {
+	containerTypes := map[string]scalingo.ContainerType{}
+	for _, containerType := range containerTypesSlice {
+		containerTypes[containerType.Name] = containerType
+	}
+	return containerTypes
 }

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -26,6 +26,8 @@ var (
 		Action: func(c *cli.Context) {
 			currentApp := appdetect.CurrentApp(c)
 
+			// The scale command with no argument displays the list of container
+			// types described for this application
 			if len(c.Args()) == 0 {
 				err := apps.ContainerTypes(currentApp)
 				if err != nil {


### PR DESCRIPTION
And probably for every non-one-off containers, but I didn't checked

The command was empty before this PR.

```
╰─$ go build -o scalingo-cli ./scalingo && ./scalingo-cli -a biniou ps
+-------+---------+-------------------+------+---------------------+
| NAME  | STATUS  |      COMMAND      | SIZE |     CREATED AT      |
+-------+---------+-------------------+------+---------------------+
| web-1 | running | sample-go-martini | M    | 2021/03/26 16:49:05 |
+-------+---------+-------------------+------+---------------------+
```

Related to [OPSB-253]


- [ ] Add a changelog entry in the section "To Be Released" of CHANGELOG.md

[OPSB-253]: https://scalingo.atlassian.net/browse/OPSB-253