### PR TITLE
fix(backup_download): no log on stdout when using '--output -' flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### To be Released
 
+* fix(backup_download): no log on stdout when using '--output -' flag [#646](https://github.com/Scalingo/cli/pull/646)
+
 ### 1.20.0
 
 * Add `env-get` command to retrieve the value of a specific environment variable [#643](https://github.com/Scalingo/cli/pull/643)

--- a/db/backup_download.go
+++ b/db/backup_download.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Scalingo/cli/config"
-	scalingoio "github.com/Scalingo/cli/io"
 	"github.com/Scalingo/go-scalingo/v4/debug"
 	"github.com/briandowns/spinner"
 	"github.com/cheggaaa/pb"
@@ -22,18 +21,6 @@ type DownloadBackupOpts struct {
 }
 
 func DownloadBackup(app, addon, backupID string, opts DownloadBackupOpts) error {
-	client, err := config.ScalingoClient()
-	if err != nil {
-		return errgo.Notef(err, "fail to get Scalingo client to download a backup")
-	}
-	if backupID == "" {
-		backups, err := client.BackupList(app, addon)
-		if err != nil {
-			return errgo.Notef(err, "fail to get the most recent backup")
-		}
-		backupID = backups[0].ID
-		scalingoio.Status("Selected the most recent backup")
-	}
 	// Output management (manage -s and -o - flags)
 	var fileWriter io.Writer
 	var logWriter io.Writer
@@ -49,6 +36,19 @@ func DownloadBackup(app, addon, backupID string, opts DownloadBackupOpts) error 
 
 	if opts.Silent {
 		logWriter = ioutil.Discard
+	}
+
+	client, err := config.ScalingoClient()
+	if err != nil {
+		return errgo.Notef(err, "fail to get Scalingo client to download a backup")
+	}
+	if backupID == "" {
+		backups, err := client.BackupList(app, addon)
+		if err != nil {
+			return errgo.Notef(err, "fail to get the most recent backup")
+		}
+		backupID = backups[0].ID
+		fmt.Fprintln(logWriter, "-----> Selected the most recent backup")
 	}
 
 	// Start a spinner when loading metadatas


### PR DESCRIPTION
```
╰─$ go build -o scalingo-cli ./scalingo && ./scalingo-cli -a my-app backups-download --addon ad-c98ed74e-fbe6-4154-9806-e957cb9304e7 --output - > b
-----> Selected the most recent backup
 305 B / 305 B [======================================//===========================================] 100.00% 0s
╭─etiennem@biniou ~/Documents/Scalingo/golang/src/github.com/Scalingo/cli ‹2.7.2› ‹fix/645/backup_dl_output*› 
╰─$ head b                                                                                                                                         
?N0p/G#Kγn
           
$.p/ -Pa.ˁĀA,b֕+x
                l~ .(xI+;EaB5q,+?0l>qW>
kinr{6pnN&WEdMƢC(h"CgHYZ!EYgwU  zEfj|w0ZVx
```

Fix #645


- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md