### PR TITLE
feat(deployment-logs): display the last deployment logs if none is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### To be Released
 
 * fix(backup_download): no log on stdout when using '--output -' flag [#646](https://github.com/Scalingo/cli/pull/646)
+* `deployment-logs` displays the last deployment logs if none is provided [#647](https://github.com/Scalingo/cli/pull/647)
 
 ### 1.20.0
 

--- a/cmd/deployments.go
+++ b/cmd/deployments.go
@@ -69,13 +69,18 @@ var (
 `,
 		Action: func(c *cli.Context) {
 			currentApp := appdetect.CurrentApp(c)
-			if len(c.Args()) == 1 {
-				err := deployments.Logs(currentApp, c.Args()[0])
-				if err != nil {
-					errorQuit(err)
-				}
-			} else {
+			if len(c.Args()) > 1 {
 				cli.ShowCommandHelp(c, "deployment-logs")
+			}
+
+			deploymentID := ""
+			if len(c.Args()) == 1 {
+				deploymentID = c.Args()[0]
+			}
+
+			err := deployments.Logs(currentApp, deploymentID)
+			if err != nil {
+				errorQuit(err)
 			}
 		},
 		BashComplete: func(c *cli.Context) {

--- a/db/backup_download.go
+++ b/db/backup_download.go
@@ -47,6 +47,9 @@ func DownloadBackup(app, addon, backupID string, opts DownloadBackupOpts) error 
 		if err != nil {
 			return errgo.Notef(err, "fail to get the most recent backup")
 		}
+		if len(backups) == 0 {
+			return errgo.New("This addon has no backup")
+		}
 		backupID = backups[0].ID
 		fmt.Fprintln(logWriter, "-----> Selected the most recent backup")
 	}


### PR DESCRIPTION
```
╰─$ go build -o scalingo-cli ./scalingo && ./scalingo-cli -a my-app deployment-logs                                     
       -----> Selected the most recent deployment (ca874847-654d-455e-a7d5-dcab193413f1)                                                                                                                           
 <-- Start deployment of my-app -->                                                                                                                                                                                
       Fetching source code                                                                                                                                                                                        
...
```


Fix https://github.com/Scalingo/one-stop-shop/issues/62


- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md