### PR TITLE
feat(integration-link-create): better catch 401 from SCM API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### To be Released
 
+* feat(integration-link-create): better catch 401 from SCM API
+
 ### 1.20.1
 
 * fix(backup_download): no log on stdout when using '--output -' flag [#646](https://github.com/Scalingo/cli/pull/646)

--- a/cmd/integration_link.go
+++ b/cmd/integration_link.go
@@ -169,13 +169,20 @@ var (
 			err = integrationlink.Create(currentApp, integrationType, integrationURL, params)
 			if err != nil {
 				scerr, ok := scalingoerrors.ErrgoRoot(err).(*http.RequestFailedError)
-				if ok && scerr.Code == 404 {
-					io.Error("Fail to create SCM repository integration: the repository has not been found")
-					io.Errorf("Check %v exists and you have the correct permissions\n", integrationURL)
-					if integrationType == scalingo.SCMGithubType || integrationType == scalingo.SCMGithubEnterpriseType {
-						io.Error("https://doc.scalingo.com/platform/deployment/deploy-with-github")
-					} else if integrationType == scalingo.SCMGitlabType || integrationType == scalingo.SCMGitlabSelfHostedType {
-						io.Error("https://doc.scalingo.com/platform/deployment/deploy-with-gitlab")
+				if ok {
+					if scerr.Code == 404 {
+						io.Error("Fail to create SCM repository integration: the repository has not been found")
+						io.Errorf("Check %v exists and you have the correct permissions\n", integrationURL)
+						if integrationType == scalingo.SCMGithubType || integrationType == scalingo.SCMGithubEnterpriseType {
+							io.Error("https://doc.scalingo.com/platform/deployment/deploy-with-github")
+						} else if integrationType == scalingo.SCMGitlabType || integrationType == scalingo.SCMGitlabSelfHostedType {
+							io.Error("https://doc.scalingo.com/platform/deployment/deploy-with-gitlab")
+						}
+					} else if scerr.Code == 403 {
+						io.Error("Fail to create SCM repository integration: the SCM API returned a 401 error.")
+						io.Error("Did you revoked the Scalingo token from your profile? In such situation, you may want to remove and re-create the SCM integration.")
+						io.Error("")
+						io.Errorf("The complete error message from the SCM API is: %s\n", scerr.APIError)
 					}
 					os.Exit(1)
 				}


### PR DESCRIPTION
```
$ scalingo -a dadazdazdazdaz integration-link-create https://gitlab.com/Moi/repo --auto-deploy --branch master
 !     Fail to create SCM repository integration: the SCM API returned a 401 error.
 !     Did you revoked the Scalingo token from your profile? In such situation, you may want to remove and re-create the SCM integration.
 !     
 !     The complete error message from the SCM API is: Request forbidden (403): {error: invalid_token}, {error_description: Token was revoked. You have to re-authorize from the user.}
```


- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md