### PR TITLE
fix(run): allow an equals sign (=) in env var values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * bump github.com/briandowns/spinner from 1.12.0 to 1.16.0
 * bump github.com/go-git/go-git/v5 from 5.4.1 to 5.4.2
 * feat(command): add command `cron-tasks` to list cron tasks of an application [#670](https://github.com/Scalingo/cli/pull/670)
+* fix(run) allow an equals sign (=) in environment variable values [#674](https://github.com/Scalingo/cli/pull/674)
 
 ### 1.20.2
 

--- a/apps/run.go
+++ b/apps/run.go
@@ -240,7 +240,7 @@ func (ctx *runContext) buildEnv(cmdEnv []string) (map[string]string, error) {
 	}
 
 	for _, cmdVar := range cmdEnv {
-		v := strings.Split(cmdVar, "=")
+		v := strings.SplitN(cmdVar, "=", 2)
 		if len(v) != 2 || len(v[0]) == 0 || len(v[1]) == 0 {
 			return nil, fmt.Errorf("Invalid environment, format is '--env VARIABLE=value'")
 		}

--- a/apps/run_test.go
+++ b/apps/run_test.go
@@ -1,0 +1,21 @@
+package apps
+
+import "testing"
+
+func TestParseEnvVar(t *testing.T) {
+	ctx := &runContext{}
+	if env, err := ctx.buildEnv([]string{"TEST=abc"}); err != nil {
+		t.Fatal(err)
+	} else if env["TEST"] != "abc" {
+		t.Fatal(env["TEST"], "should be abc")
+	}
+}
+
+func TestParseEnvVarWithEqualSign(t *testing.T) {
+	ctx := &runContext{}
+	if env, err := ctx.buildEnv([]string{"TEST=a=b"}); err != nil {
+		t.Fatal(err)
+	} else if env["TEST"] != "a=b" {
+		t.Fatal(env["TEST"], "should be a=b")
+	}
+}


### PR DESCRIPTION
Fixes #673.

I took the liberty of adding a couple of tests for the `buildEnv` function. I don't write Go daily, so it's likely I did something suboptimally, please feel free to let me know.

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md
