### PR TITLE
fix(crontasks): display an empty table in case of 404

### DIFF
--- a/cmd/error.go
+++ b/cmd/error.go
@@ -10,15 +10,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/stvp/rollbar"
-	"gopkg.in/errgo.v1"
-
 	"github.com/Scalingo/cli/config"
 	"github.com/Scalingo/cli/io"
 	"github.com/Scalingo/go-scalingo/v4"
 	"github.com/Scalingo/go-scalingo/v4/debug"
 	httpclient "github.com/Scalingo/go-scalingo/v4/http"
 	"github.com/Scalingo/go-utils/errors"
+	"github.com/stvp/rollbar"
+	"gopkg.in/errgo.v1"
 )
 
 type Sysinfo struct {

--- a/crontasks/list.go
+++ b/crontasks/list.go
@@ -1,21 +1,29 @@
 package crontasks
 
 import (
-	"github.com/Scalingo/cli/config"
-	"github.com/olekukonko/tablewriter"
-	"github.com/pkg/errors"
 	"os"
+
+	"github.com/Scalingo/cli/config"
+	httpclient "github.com/Scalingo/go-scalingo/v4/http"
+	"github.com/Scalingo/go-utils/errors"
+	"github.com/olekukonko/tablewriter"
+	"gopkg.in/errgo.v1"
 )
 
 func List(app string) error {
 	client, err := config.ScalingoClient()
 	if err != nil {
-		return errors.Wrap(err, "fail to get Scalingo client")
+		return errgo.Notef(err, "fail to get Scalingo client")
 	}
 
 	cronTasks, err := client.CronTasksGet(app)
 	if err != nil {
-		return errors.Wrap(err, "fail to get cron tasks")
+		rootError := errors.ErrgoRoot(err)
+		if !httpclient.IsRequestFailedError(rootError) || rootError.(*httpclient.RequestFailedError).Code != 404 {
+			return errgo.Notef(err, "fail to get cron tasks")
+		}
+
+		// A 404 only means there is no cron task configured on the application. In this case, we want to display an empty table.
 	}
 
 	t := tablewriter.NewWriter(os.Stdout)

--- a/deployments/list.go
+++ b/deployments/list.go
@@ -21,31 +21,26 @@ func List(app string) error {
 		return errgo.Mask(err)
 	}
 
-	if len(deployments) == 0 {
+	t := tablewriter.NewWriter(os.Stdout)
+	t.SetHeader([]string{"ID", "Date", "Duration", "User", "Git Ref", "Status"})
 
-	} else {
-		t := tablewriter.NewWriter(os.Stdout)
-		t.SetHeader([]string{"ID", "Date", "Duration", "User", "Git Ref", "Status"})
-
-		for _, deployment := range deployments {
-			var duration string
-			if deployment.Duration != 0 {
-				d, _ := time.ParseDuration(fmt.Sprintf("%ds", deployment.Duration))
-				duration = d.String()
-			} else {
-				duration = "n/a"
-			}
-			t.Append([]string{deployment.ID,
-				deployment.CreatedAt.Format(utils.TimeFormat),
-				duration,
-				deployment.User.Username,
-				deployment.GitRef,
-				string(deployment.Status),
-			})
+	for _, deployment := range deployments {
+		var duration string
+		if deployment.Duration != 0 {
+			d, _ := time.ParseDuration(fmt.Sprintf("%ds", deployment.Duration))
+			duration = d.String()
+		} else {
+			duration = "n/a"
 		}
-		t.Render()
-
+		t.Append([]string{deployment.ID,
+			deployment.CreatedAt.Format(utils.TimeFormat),
+			duration,
+			deployment.User.Username,
+			deployment.GitRef,
+			string(deployment.Status),
+		})
 	}
+	t.Render()
 
 	return nil
 }

--- a/deployments/list.go
+++ b/deployments/list.go
@@ -18,7 +18,7 @@ func List(app string) error {
 	}
 	deployments, err := c.DeploymentList(app)
 	if err != nil {
-		return errgo.Mask(err)
+		return errgo.Notef(err, "fail to list the application deployments")
 	}
 
 	t := tablewriter.NewWriter(os.Stdout)


### PR DESCRIPTION
Displaying an empty table when there is nothing is the current behaviour. See for instance the collaborators, autoscalers, alerts, etc. 


Related to [CRON-66]

- [ ] ~Add a changelog entry in the section "To Be Released" of CHANGELOG.md~: no need, this is still part of the upcoming cron product

[CRON-66]: https://scalingo.atlassian.net/browse/CRON-66