### PR TITLE
fix(update): change warning message stream from stdout to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### To be Released
 
+* fix(warning-data-stream): change data stream on which warning is displayed from stdout to stderr [#698](https://github.com/Scalingo/cli/pull/698)
 * feat(pgsql-console): add `psql-console` and `postgresql-console` aliases for `pgsql-console` command and replace duplicated commands with aliases [#693](https://github.com/Scalingo/cli/pull/693)
 * feat(router-logs): add command `router-logs` to enable/disable router logs on your application [#692](https://github.com/Scalingo/cli/pull/692)
 * feat(open): add command `open` to open app on default browser [#691](https://github.com/Scalingo/cli/pull/691)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### To be Released
 
-* fix(warning-data-stream): change data stream on which warning is displayed from stdout to stderr [#698](https://github.com/Scalingo/cli/pull/698)
+* fix(update): change data stream on which warning is displayed from stdout to stderr [#698](https://github.com/Scalingo/cli/pull/698)
 * feat(pgsql-console): add `psql-console` and `postgresql-console` aliases for `pgsql-console` command and replace duplicated commands with aliases [#693](https://github.com/Scalingo/cli/pull/693)
 * feat(router-logs): add command `router-logs` to enable/disable router logs on your application [#692](https://github.com/Scalingo/cli/pull/692)
 * feat(open): add command `open` to open app on default browser [#691](https://github.com/Scalingo/cli/pull/691)

--- a/update/check.go
+++ b/update/check.go
@@ -58,8 +58,8 @@ func Check() error {
 		return nil
 	}
 
-	io.Statusf(io.BoldRed("Your Scalingo client (%s) is out-of-date: some features may not work correctly.\n"), version)
-	io.Infof(io.BoldRed("Please update to '%s' by reinstalling it: https://cli.scalingo.com\n"), lastVersion)
+	io.Errorf(io.BoldRed("Your Scalingo client (%s) is out-of-date: some features may not work correctly.\n"), version)
+	io.Errorf(io.BoldRed("Please update to '%s' by reinstalling it: https://cli.scalingo.com\n"), lastVersion)
 	return nil
 }
 


### PR DESCRIPTION
- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md

Fix #695 