### PR TITLE
fix(addons-info): remove the need for the --addon option

### DIFF
--- a/cmd/addons.go
+++ b/cmd/addons.go
@@ -121,20 +121,20 @@ var (
 		Name:     "addons-info",
 		Category: "Addons",
 		Usage:    "Display information about an add-on attached to your app",
-		Flags:    []cli.Flag{appFlag, addonFlag},
+		Flags:    []cli.Flag{appFlag},
 		Description: ` Display information about an add-on attached to your app:
     $ scalingo --app my-app addons-info --addon <addon-id>
 
 		# See also 'addons' and 'addons-upgrade'
 `,
 		Action: func(c *cli.Context) {
-			if len(c.Args()) != 0 {
+			if len(c.Args()) != 1 {
 				cli.ShowCommandHelp(c, "addons-info")
 				return
 			}
 
 			currentApp := appdetect.CurrentApp(c)
-			currentAddon := addonName(c)
+			currentAddon := c.Args()[0]
 
 			err := addons.Info(currentApp, currentAddon)
 			if err != nil {

--- a/cmd/autocomplete/addons_remove.go
+++ b/cmd/autocomplete/addons_remove.go
@@ -21,7 +21,6 @@ func AddonsRemoveAutoComplete(c *cli.Context) error {
 	}
 	resources, err := client.AddonsList(appName)
 	if err == nil {
-
 		for _, resource := range resources {
 			fmt.Println(resource.ResourceID)
 		}


### PR DESCRIPTION
Fix #699

```
╰─$ go build -o scalingo-cli ./scalingo && ./scalingo-cli -a biniou addons-info ad-97fe3f10-ed53-4459-8e40-bb41985562d1
+------------------------+------------------------+
| Database Type          | postgresql             |
| Version                | 13.3.0-2               |
| Status                 | running                |
| Plan                   | postgresql-starter-512 |
| Force TLS              | disabled               |
| Internet Accessibility | disabled               |
+------------------------+------------------------+
```


- [ ] Add a changelog entry in the section "To Be Released" of CHANGELOG.md