### PR TITLE
fix(term): prefer the use of the os package rather than syscall

### DIFF
--- a/term/password.go
+++ b/term/password.go
@@ -2,7 +2,7 @@ package term
 
 import (
 	"fmt"
-	"syscall"
+	"os"
 
 	"golang.org/x/term"
 	"gopkg.in/errgo.v1"
@@ -10,7 +10,7 @@ import (
 
 func Password(prompt string) (string, error) {
 	fmt.Print(prompt)
-	bytePassword, err := term.ReadPassword(syscall.Stdin)
+	bytePassword, err := term.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
 		return "", errgo.Notef(err, "fail to read the password on stdin")
 	} else {


### PR DESCRIPTION
The syscall package documentation states:

> Package syscall contains an interface to the low-level operating system primitives. The details vary depending on the underlying system. [...] The primary use of syscall is inside other packages that provide a more portable interface to the system, such as "os", "time" and "net". Use those packages rather than this one if you can.

https://pkg.go.dev/syscall

With this PR, the CLI compiles again on all OS