### PR TITLE
 fix(install): disable CLI update checker 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * feat(logs): allow to filter logs to only show router logs [#707](https://github.com/Scalingo/cli/pull/707)
 * build(deps): bump github.com/briandowns/spinner from 1.16.0 to 1.18.0
+* fix(install): correctly parse the old and new versions [#710](https://github.com/Scalingo/cli/pull/710)
 
 ### 1.22.0
 

--- a/dists/install.sh
+++ b/dists/install.sh
@@ -125,8 +125,9 @@ main() {
   target="$target_dir/scalingo"
 
   if [ -x "$target" -a -z "$yes_to_overwrite" ] ; then
-    new_version=$($exe_path -v | cut -d' ' -f4)
-    old_version=$("$target" -v | cut -d' ' -f4)
+    export DISABLE_UPDATE_CHECKER=true
+    new_version=$($exe_path --version | cut -d' ' -f4)
+    old_version=$("$target" --version | cut -d' ' -f4)
     warn "Scalingo client is already installed (version ${old_version})\n"
     info "Do you want to replace it with version ${new_version}? [Y/n] "
 


### PR DESCRIPTION
The install script does not need to check if an update is avbailable when calling `scalingo --version`.

Fix #536 

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md