### PR TITLE
feat(make-release): use gox

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,11 +33,11 @@ jobs:
       - name: Build the binaries
         if: startsWith(github.ref, 'refs/tags/')
         run: |
+          go install github.com/mitchellh/gox@latest
           ./dists/make-release.sh -v ${{ steps.tag_name.outputs.TAG_NAME }}
 
       - name: Release the new version
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
-          body: Please refer to the [CHANGELOG.md](https://github.com/Scalingo/cli/blob/${{ steps.tag_name.outputs.TAG_NAME }}/CHANGELOG.md) file.
           files: ./bin/${{ steps.tag_name.outputs.TAG_NAME }}/*.{zip,tar.gz}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### To be Released
 
+* feat(make-release): use gox [#747](https://github.com/Scalingo/cli/pull/747)
 * fix(install.sh): better error message if fails to get the version [#748](https://github.com/Scalingo/cli/pull/748)
 * feat(logs): possibility to get the addon logs by using its type (e.g. Redis) [#745](https://github.com/Scalingo/cli/pull/745)
 * fix(error): interpret raw newline [#744](https://github.com/Scalingo/cli/pull/744)

--- a/dists/make-release.sh
+++ b/dists/make-release.sh
@@ -1,81 +1,84 @@
 #!/bin/bash
 
+# Override the pushd and popd commands to make them silent
+pushd () {
+  command pushd "$@" > /dev/null
+}
+
+popd () {
+  command popd "$@" > /dev/null
+}
+
 [ "$DEBUG" = "1" ] && set -x
 set -e
 
-VERSION=""
-
-while getopts :v:b OPT; do
+version=""
+parallel_jobs="-1"
+while getopts :v:j: OPT; do
   case $OPT in
+    j)
+      parallel_jobs=$OPTARG
+      ;;
     v)
-      VERSION=$OPTARG
+      version=$OPTARG
       ;;
   esac
 done
 
-if [ -z $VERSION ] ; then
+if [ -z $version ] ; then
   echo "Usage: $0 -v <version>" >&2
   exit 1
 fi
 
-bin_dir="bin/$VERSION"
-mkdir -p $bin_dir
+# Move to the directory where lie this script
+_cur_dir=$(cd $(dirname $0) && pwd)
+cd $_cur_dir
 
-function build_for() {
-  local os=$1
-  local archive_type=$2
+pushd ${_cur_dir}/../scalingo
 
-  for arch in amd64 arm64 386 ; do
-    if [ "$os" = "darwin" ] && [ "$arch" = "386" ] ; then
-      continue
-    fi
+echo "Remove previously compiled binaries"
+rm -f ${_cur_dir}/../scalingo/scalingo*
 
-    pushd scalingo
+bin_dir="${_cur_dir}/../bin/$version"
 
-    [ -e "./scalingo" ] && rm ./scalingo
-    [ -e "./scalingo.exe" ] && rm ./scalingo.exe
-    GOOS=$os GOARCH=$arch go build -ldflags " \
-      -X main.buildstamp=$(date -u '+%Y-%m-%d_%I:%M:%S%p') \
+echo "Compiling the binaries for all architectures"
+operating_systems="linux freebsd openbsd darwin windows"
+architectures="amd64 arm64 386"
+ignore_osarch="!darwin/386"
+gox -parallel $parallel_jobs -os="${operating_systems}" -arch="${architectures}" -osarch="${ignore_osarch}" \
+    -ldflags "-X main.buildstamp=$(date -u '+%Y-%m-%d_%I:%M:%S%p') \
       -X main.githash=$(git rev-parse HEAD) \
-      -X main.VERSION=$VERSION"
+      -X main.version=$version"
 
-    release_dir="scalingo_${VERSION}_${os}_${arch}"
-    archive_dir="$bin_dir/$release_dir"
+echo ""
+echo "Binaries compilation finished, archiving them"
 
-    popd
-    mkdir -p $archive_dir
+for binary in ./scalingo*; do
+  echo "--> Create the archive for $(basename $binary)"
 
-    bin="scalingo/scalingo"
-    if [ "$os" = "windows" ] ; then
-      bin="scalingo/scalingo.exe"
-    fi
-    cp $bin $archive_dir
-    cp README.md $archive_dir
-    cp LICENSE $archive_dir
+  # binary contains a string like "./scalingo_windows_386.exe"
+  os=$(basename $binary | cut -d "." -f 1 | cut -d "_" -f 2)
+  arch=$(basename $binary | cut -d "." -f 1 | cut -d "_" -f 3)
+  release_dir="scalingo_${version}_${os}_${arch}"
+  archive_dir="$bin_dir/$release_dir"
+  mkdir -p $archive_dir
 
-    pushd $bin_dir
-    if [ "$archive_type" = "tarball" ] ; then
-      tar czvf "${release_dir}.tar.gz" "$release_dir"
-    else
-      zip "${release_dir}.zip" $(find "${release_dir}")
-    fi
-    popd
-  done
-}
+  bin="scalingo"
+  if [ "$os" = "windows" ] ; then
+    bin="scalingo.exe"
+  fi
 
-if uname -a | grep -iq Linux ; then
-  build_for "linux" "tarball"
-  build_for "freebsd"
-  build_for "openbsd"
-  build_for "darwin"
-  build_for "windows"
-fi
-if uname -a | grep -iq Darwin ; then
-  build_for "darwin"
-fi
-if uname -a | grep -iq Mingw ; then
-  build_for "windows"
-fi
-if uname -a | grep -iq Cygwin ; then
-  build_for windows
-fi
+  mv $binary ${archive_dir}/${bin}
+  cp ${_cur_dir}/../README.md $archive_dir
+  cp ${_cur_dir}/../LICENSE $archive_dir
+
+  pushd $bin_dir
+  if [ "$os" = "linux" ] ; then
+    tar czf "${release_dir}.tar.gz" "$release_dir"
+  else
+    zip "${release_dir}.zip" $(find "${release_dir}") > /dev/null
+  fi
+  popd
+done
+
+popd


### PR DESCRIPTION
Execution example:

```
 emichon@biniou  ~/Documents/Scalingo/golang/src/github.com/Scalingo/cli   fix/739/gox ✚  ./dists/make-release.sh -j 3 -v $VERSION
Remove previously compiled binaries
Compiling the binaries for all architectures
Number of parallel builds: 3

-->     linux/amd64: github.com/Scalingo/cli/scalingo
-->     windows/386: github.com/Scalingo/cli/scalingo
-->     linux/arm64: github.com/Scalingo/cli/scalingo
-->     freebsd/386: github.com/Scalingo/cli/scalingo
-->   freebsd/amd64: github.com/Scalingo/cli/scalingo
-->    darwin/amd64: github.com/Scalingo/cli/scalingo
-->   openbsd/amd64: github.com/Scalingo/cli/scalingo
-->     openbsd/386: github.com/Scalingo/cli/scalingo
-->    darwin/arm64: github.com/Scalingo/cli/scalingo
-->   windows/amd64: github.com/Scalingo/cli/scalingo
-->       linux/386: github.com/Scalingo/cli/scalingo

Binaries compilation finished, archiving them
--> Create the archive for scalingo_darwin_amd64
--> Create the archive for scalingo_darwin_arm64
--> Create the archive for scalingo_freebsd_386
--> Create the archive for scalingo_freebsd_amd64
--> Create the archive for scalingo_linux_386
--> Create the archive for scalingo_linux_amd64
--> Create the archive for scalingo_linux_arm64
--> Create the archive for scalingo_openbsd_386
--> Create the archive for scalingo_openbsd_amd64
--> Create the archive for scalingo_windows_386.exe
--> Create the archive for scalingo_windows_amd64.exe
 emichon@biniou  ~/Documents/Scalingo/golang/src/github.com/Scalingo/cli   fix/739/gox ±✚  ll bin/1.24.0 
total 91M
drwxrwxr-x 2 emichon emichon 4.0K Jul 22 16:24 scalingo_1.24.0_darwin_amd64
-rw-rw-r-- 1 emichon emichon 8.2M Jul 22 16:24 scalingo_1.24.0_darwin_amd64.zip
drwxrwxr-x 2 emichon emichon 4.0K Jul 22 16:24 scalingo_1.24.0_darwin_arm64
-rw-rw-r-- 1 emichon emichon 8.0M Jul 22 16:24 scalingo_1.24.0_darwin_arm64.zip
drwxrwxr-x 2 emichon emichon 4.0K Jul 22 16:24 scalingo_1.24.0_freebsd_386
-rw-rw-r-- 1 emichon emichon 8.3M Jul 22 16:24 scalingo_1.24.0_freebsd_386.zip
drwxrwxr-x 2 emichon emichon 4.0K Jul 22 16:24 scalingo_1.24.0_freebsd_amd64
-rw-rw-r-- 1 emichon emichon 8.4M Jul 22 16:24 scalingo_1.24.0_freebsd_amd64.zip
drwxrwxr-x 2 emichon emichon 4.0K Jul 22 16:24 scalingo_1.24.0_linux_386
-rw-rw-r-- 1 emichon emichon 8.3M Jul 22 16:24 scalingo_1.24.0_linux_386.tar.gz
drwxrwxr-x 2 emichon emichon 4.0K Jul 22 16:24 scalingo_1.24.0_linux_amd64
-rw-rw-r-- 1 emichon emichon 8.4M Jul 22 16:24 scalingo_1.24.0_linux_amd64.tar.gz
drwxrwxr-x 2 emichon emichon 4.0K Jul 22 16:24 scalingo_1.24.0_linux_arm64
-rw-rw-r-- 1 emichon emichon 7.9M Jul 22 16:24 scalingo_1.24.0_linux_arm64.tar.gz
drwxrwxr-x 2 emichon emichon 4.0K Jul 22 16:24 scalingo_1.24.0_openbsd_386
-rw-rw-r-- 1 emichon emichon 8.3M Jul 22 16:24 scalingo_1.24.0_openbsd_386.zip
drwxrwxr-x 2 emichon emichon 4.0K Jul 22 16:24 scalingo_1.24.0_openbsd_amd64
-rw-rw-r-- 1 emichon emichon 8.3M Jul 22 16:24 scalingo_1.24.0_openbsd_amd64.zip
drwxrwxr-x 2 emichon emichon 4.0K Jul 22 16:24 scalingo_1.24.0_windows_386
-rw-rw-r-- 1 emichon emichon 8.6M Jul 22 16:24 scalingo_1.24.0_windows_386.zip
drwxrwxr-x 2 emichon emichon 4.0K Jul 22 16:24 scalingo_1.24.0_windows_amd64
-rw-rw-r-- 1 emichon emichon 8.6M Jul 22 16:24 scalingo_1.24.0_windows_amd64.zip
```

Fix #739

I wonder if it can fix #609 or #735?

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md