### PR TITLE
fix(workflows): add contents write permissions

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,7 +2,10 @@ name: Dependabot auto-approve
 on: pull_request
 
 permissions:
+  # Mandatory for both the auto-merge enabling and approval steps
   pull-requests: write
+  # Mandatory for the auto-merge enabling step
+  contents: write
 
 jobs:
   dependabot:


### PR DESCRIPTION
as per the official doc: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions\#enable-auto-merge-on-a-pull-request

The Dependabot PRs from past month batch hadn't been auto-merged due to permission problem.

- [ ] ~Add a changelog entry in the section "To Be Released" of CHANGELOG.md~ Irrelevant