### PR TITLE
feat(workflows/publish): split in two jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,10 +4,9 @@ on:
   push:
 
 jobs:
-  build:
-    name: GoReleaser build
+  tests:
+    name: Unit Tests
     runs-on: ubuntu-latest
-
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -24,6 +23,11 @@ jobs:
       - name: Execute the tests
         run: go test -race ./...
 
+  release:
+    needs: tests
+    name: GoReleaser Build
+    runs-on: ubuntu-latest
+    steps:
       - name: Run GoReleaser
         if: startsWith(github.ref, 'refs/tags/')
         uses: goreleaser/goreleaser-action@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,18 +8,12 @@ jobs:
     name: Unit Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0 # See: https://goreleaser.com/ci/actions/
-
-      - name: Setup Go environment
-        uses: actions/setup-go@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
         with:
           go-version-file: "go.mod"
           check-latest: true
       - run: go version
-
       - name: Execute the tests
         run: go test -race ./...
 
@@ -29,6 +23,14 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # See: https://goreleaser.com/ci/actions/
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: "go.mod"
+          check-latest: true
+      - run: go version
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,10 +26,10 @@ jobs:
   release:
     needs: tests
     name: GoReleaser Build
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Run GoReleaser
-        if: startsWith(github.ref, 'refs/tags/')
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest


### PR DESCRIPTION
The `release` job is executed after `tests`, if it's successful.

Based on this doc: https://docs.github.com/en/actions/using-workflows/about-workflows#creating-dependent-jobs