### PR TITLE
Bump version 1.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### To be Released
 
+# 1.24.0
+
 * feat(db): environment variable name is customizable [#759](https://github.com/Scalingo/cli/issues/759)
 * feat(goreleaser): use goreleaser to make releases using github action [#752](https://github.com/Scalingo/cli/issues/752)
 * feat(make-release): use gox [#747](https://github.com/Scalingo/cli/pull/747)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Scalingo-CLI v1.23.0
+# Scalingo-CLI v1.24.0
 
 ![publish workflow](https://github.com/Scalingo/cli/actions/workflows/publish.yml/badge.svg)
 
@@ -56,7 +56,7 @@ USAGE:
    scalingo-cli [global options] command [command options] [arguments...]
 
 VERSION:
-   1.23.0
+   1.24.0
 
 AUTHOR:
    Scalingo Team <hello@scalingo.com>
@@ -259,12 +259,12 @@ the commit for the version bump.
 
 ```bash
 git checkout <base commit ID>
-git checkout -b v1.23.0
+git checkout -b v1.24.0
 git cherry-pick -m 1 <commit ID number 1>
 git cherry-pick -m 1 <commit ID number 2>
 ...
 git cherry-pick -m 1 <commit ID number X>
-git push --set-upstream origin v1.23.0
+git push --set-upstream origin v1.24.0
 ```
 
 ### New Version Bump
@@ -278,18 +278,18 @@ Bump new version number in:
 And commit these changes:
 
 ```bash
-git switch --create release/1.23.0
+git switch --create release/1.24.0
 git add .
-git commit -m "Bump version 1.23.0"
-git push --set-upstream origin release/1.23.0
+git commit -m "Bump version 1.24.0"
+git push --set-upstream origin release/1.24.0
 gh pr create --reviewer=EtienneM --title "$(git log -1 --pretty=%B)"
 ```
 
 #### Tag the New Release
 
 ```bash
-git tag 1.23.0
-git push origin master 1.23.0
+git tag 1.24.0
+git push origin master 1.24.0
 ```
 
 Pushing the tag triggers a GitHub Action which builds the cross-platform binaries and create a new release.
@@ -304,6 +304,6 @@ It serves as cache between GitHub and our customers for a more efficient check o
 
 You can now update the [changelog](https://doc.scalingo.com/changelog) and tweet about it!
 
-> [Changelog] CLI - Release of version 1.23.0 https://cli.scalingo.com - More news at https://changelog.scalingo.com #cli #paas #changelog #bugfix
+> [Changelog] CLI - Release of version 1.24.0 https://cli.scalingo.com - More news at https://changelog.scalingo.com #cli #paas #changelog #bugfix
 
 Add in a tweets thread the changelog of this new version.

--- a/config/version.go
+++ b/config/version.go
@@ -1,3 +1,3 @@
 package config
 
-var Version = "1.23.0"
+var Version = "1.24.0"


### PR DESCRIPTION
> [Changelog] CLI - Release of version 1.24.0 https://cli.scalingo.com - More news at https://changelog.scalingo.com #cli #paas #changelog #bugfix


