### PR TITLE
fix(integration-link): no error when --auto-deploy and no branch specified

### DIFF
--- a/cmd/integration_link.go
+++ b/cmd/integration_link.go
@@ -184,10 +184,12 @@ var (
 						io.Error("Did you revoked the Scalingo token from your profile? In such situation, you may want to remove and re-create the SCM integration.")
 						io.Error("")
 						io.Errorf("The complete error message from the SCM API is: %s\n", scerr.APIError)
+					} else {
+						errorQuit(err)
 					}
-					os.Exit(1)
+				} else {
+					errorQuit(err)
 				}
-				errorQuit(err)
 			}
 			return nil
 		},


### PR DESCRIPTION
Fix the problem that did not display the error in the specific case where the auto deploy flag is activated but no branch to deploy is specified.

In addition, all errors are now displayed instead of being skipped.

```sh
$ scalingo -a escudierq-test integration-link-create --auto-deploy https://github.com/QuentinEscudierScalingo/sample-go-martini
 !     An error occurred:
       fail to create the repo link: fail to create the SCM repo link: * auto_deploy_enabled → branch can't be blank
```

Fixes #765