### PR TITLE
feat(publish): compile Windows release on Windows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,6 @@
 name: Test and Release Go CLI
 
-on:
-  push:
+on: [push]
 
 jobs:
   tests:
@@ -13,13 +12,13 @@ jobs:
         with:
           go-version-file: "go.mod"
           check-latest: true
-      - run: go version
+          cache: true
       - name: Execute the tests
         run: go test -race ./...
 
-  release:
+  releases:
     needs: tests
-    name: GoReleaser Build
+    name: GoReleaser Build on All OS but Windows
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +29,7 @@ jobs:
         with:
           go-version-file: "go.mod"
           check-latest: true
-      - run: go version
+          cache: true
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
@@ -38,3 +37,28 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  releases-windows:
+    needs: tests
+    name: GoReleaser Build on Windows
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # See: https://goreleaser.com/ci/actions/
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: "go.mod"
+          check-latest: true
+          cache: true
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        with:
+          version: latest
+          args: release --config .goreleaser-windows.yaml --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: List files in the repository
+        run: |
+          ls ${{ github.workspace }}/dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,6 +59,3 @@ jobs:
           args: release --config .goreleaser-windows.yaml --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: List files in the repository
-        run: |
-          ls ${{ github.workspace }}/dist

--- a/.goreleaser-windows.yaml
+++ b/.goreleaser-windows.yaml
@@ -1,0 +1,34 @@
+# We need a specific GoRelease file for Windows because we don't want to use Go cross compile feature. We prefer compiling on an actual Windows.
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - id: scalingo
+    binary: scalingo
+    main: ./scalingo
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - 386
+
+    # Custom ldflags templates.
+    # https://goreleaser.com/customization/templates/
+    ldflags: -X main.buildstamp={{.Date}}
+      -X main.githash={{.FullCommit}}
+
+archives:
+  - name_template: 'scalingo_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+    wrap_in_directory: true
+    format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: "checksums_windows.txt"
+changelog:
+  use: github-native
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,13 +2,11 @@ before:
   hooks:
     - go mod tidy
 builds:
-  -
-    id: scalingo
+  - id: scalingo
     binary: scalingo
     main: ./scalingo
     goos:
       - linux
-      - windows
       - darwin
       - freebsd
       - openbsd
@@ -22,22 +20,17 @@ builds:
 
     # Custom ldflags templates.
     # https://goreleaser.com/customization/templates/
-    ldflags:
-        -X main.buildstamp={{.Date}}
-        -X main.githash={{.FullCommit}}
+    ldflags: -X main.buildstamp={{.Date}}
+      -X main.githash={{.FullCommit}}
 
 archives:
-  -
-    name_template: 'scalingo_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+  - name_template: 'scalingo_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     wrap_in_directory: true
-    format_overrides:
-      - goos: windows
-        format: zip
 checksum:
-  name_template: 'checksums.txt'
+  name_template: "checksums.txt"
 changelog:
   use: github-native
   filters:
     exclude:
-      - '^docs:'
-      - '^test:'
+      - "^docs:"
+      - "^test:"


### PR DESCRIPTION
With this PR, the `publish` action has two different jobs for the GoReleaser execution:

- `releases-windows`: execute GoReleaser on a Windows server so that we don't use Go cross compile feature. This is to prevent issues such as the one described in #734.
- `releases`: execute GoReleaser on a Ubuntu server for OpenBSD, Linux and macOS using Go cross compile feature. 

All these features are added as assets of a single GitHub release. You can see an example of execution on my fork: https://github.com/EtienneM/cli/releases/tag/1.25.2-beta8. One of the cons from my perspective is that we have two different files for the checksums. 

Related to #734 and #735

- [ ] ~Add a changelog entry in the section "To Be Released" of CHANGELOG.md~ no changelog entry, this is an internal change