### PR TITLE
feat(db-console): add `influx-console` and `mongodb-console` aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### To be Released
 
 * feat(logs): allow DB type aliases [#829](https://github.com/Scalingo/cli/pull/829)
+* feat(db-console): add `influx-console` and `mongodb-console` aliases [#830](https://github.com/Scalingo/cli/pull/830)
 
 ### 1.26.1
 

--- a/README.md
+++ b/README.md
@@ -136,10 +136,10 @@ COMMANDS:
 
    Databases:
      redis-console                                    Run an interactive console with your Redis addon
-     mongo-console                                    Run an interactive console with your MongoDB addon
+     mongo-console, mongodb-console                   Run an interactive console with your MongoDB addon
      mysql-console                                    Run an interactive console with your MySQL addon
      pgsql-console, psql-console, postgresql-console  Run an interactive console with your PostgreSQL addon
-     influxdb-console                                 Run an interactive console with your InfluxDB addon
+     influxdb-console, influx-console                 Run an interactive console with your InfluxDB addon
 
    Deployment:
      deployments                                       List app deployments

--- a/cmd/influxdb.go
+++ b/cmd/influxdb.go
@@ -12,6 +12,7 @@ import (
 var (
 	InfluxDBConsoleCommand = cli.Command{
 		Name:     "influxdb-console",
+		Aliases:  []string{"influx-console"},
 		Category: "Databases",
 		Usage:    "Run an interactive console with your InfluxDB addon",
 		Flags: []cli.Flag{&appFlag,

--- a/cmd/mongo.go
+++ b/cmd/mongo.go
@@ -12,6 +12,7 @@ import (
 var (
 	MongoConsoleCommand = cli.Command{
 		Name:     "mongo-console",
+		Aliases:  []string{"mongodb-console"},
 		Category: "Databases",
 		Usage:    "Run an interactive console with your MongoDB addon",
 		Flags: []cli.Flag{&appFlag,


### PR DESCRIPTION
It actually already exists for `pgsql-console`.

Fix #828

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md