### PR TITLE
feat(send-signal): send-signal command added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * fix(commands): display help usage message if needed [#835](https://github.com/Scalingo/cli/pull/835)
 * feat(logs): allow DB type aliases [#829](https://github.com/Scalingo/cli/pull/829)
 * feat(db-console): add `influx-console` and `mongodb-console` aliases [#830](https://github.com/Scalingo/cli/pull/830)
-
+* feat(send-signal): `send-signal` command added [#833](https://github.com/Scalingo/cli/pull/833)
 ### 1.26.1
 
 * deps(urfave/cli): Bumpd from 2.17.1 to 2.23.5: fix options display regression in --help [#814](https://github.com/Scalingo/cli/pull/814)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * feat(logs): allow DB type aliases [#829](https://github.com/Scalingo/cli/pull/829)
 * feat(db-console): add `influx-console` and `mongodb-console` aliases [#830](https://github.com/Scalingo/cli/pull/830)
 * feat(send-signal): `send-signal` command added [#833](https://github.com/Scalingo/cli/pull/833)
+
 ### 1.26.1
 
 * deps(urfave/cli): Bumpd from 2.17.1 to 2.23.5: fix options display regression in --help [#814](https://github.com/Scalingo/cli/pull/814)

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ DISABLE_UPDATE_CHECKER=true
 ## Command Help
 
 ```
+Incorrect Usage: flag: help requested
+
 NAME:
    Scalingo Client - Manage your apps and containers
 
@@ -65,16 +67,18 @@ COMMANDS:
      help  Shows a list of commands or help for one command
 
    Addons:
-     addons            List used add-ons
-     addons-add        Provision an add-on for your application
-     addons-remove     Remove an existing addon from your app
-     addons-upgrade    Upgrade or downgrade an add-on attached to your app
-     addons-info       Display information about an add-on attached to your app
-     backups-config    Configure the periodic backups of a database
-     backups           List backups for an addon
-     backups-create    Ask for a new backup
-     backups-download  Download a backup
-     backup-download   Download a backup
+     addons                    List used add-ons
+     addons-add                Provision an add-on for your application
+     addons-remove             Remove an existing addon from your app
+     addons-upgrade            Upgrade or downgrade an add-on attached to your app
+     addons-info               Display information about an add-on attached to your app
+     backups-config            Configure the periodic backups of a database
+     database-enable-feature   Enable a togglable feature from a database
+     database-disable-feature  Enable a togglable feature from a database
+     backups                   List backups for an addon
+     backups-create            Ask for a new backup
+     backups-download          Download a backup
+     backup-download           Download a backup
 
    Addons - Global:
      addons-list   List all addons
@@ -96,11 +100,12 @@ COMMANDS:
      dashboard               Open app dashboard on default web browser
      logs, l                 Get the logs of your applications
      logs-archives, la       Get the logs archives of your applications and databases
-     run                     Run any command for your app
+     run, r                  Run any command for your app
      one-off-stop            Stop a running one-off container
      ps                      Display your application containers
-     scale                   Scale your application instantly
+     scale, s                Scale your application instantly
      restart                 Restart processes of your app
+     send-signal             Send SIGUSR1/2 to your application containers
      force-https             Enable/Disable automatic redirection of traffic to HTTPS for your application
      sticky-session          Enable/Disable sticky sessions for your application
      router-logs             Enable/disable router logs for your application

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ COMMANDS:
      ps                      Display your application containers
      scale, s                Scale your application instantly
      restart                 Restart processes of your app
-     send-signal             Send SIGUSR1/2 to your application containers
+     send-signal, kill       Send SIGUSR1 or SIGUSR2 to your application containers
      force-https             Enable/Disable automatic redirection of traffic to HTTPS for your application
      sticky-session          Enable/Disable sticky sessions for your application
      router-logs             Enable/disable router logs for your application

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ DISABLE_UPDATE_CHECKER=true
 ## Command Help
 
 ```
-Incorrect Usage: flag: help requested
-
 NAME:
    Scalingo Client - Manage your apps and containers
 

--- a/apps/sendsignal.go
+++ b/apps/sendsignal.go
@@ -9,8 +9,8 @@ import (
 	"github.com/Scalingo/cli/config"
 )
 
-func SendSignal(ctx context.Context, app string, signal string, args []string) error {
-	if len(args) == 0 {
+func SendSignal(ctx context.Context, app string, signal string, containerNames []string) error {
+	if len(containerNames) == 0 {
 		return errgo.New("at least one container name should be given")
 	}
 	c, err := config.ScalingoClient(ctx)
@@ -18,12 +18,12 @@ func SendSignal(ctx context.Context, app string, signal string, args []string) e
 		return errgo.Notef(err, "fail to get Scalingo client to send signal to application containers")
 	}
 
-	for _, container := range args {
-		err := c.AppsContainersSendSignal(ctx, app, signal, container)
+	for _, containerName := range containerNames {
+		err := c.ContainersSendSignal(ctx, app, signal, containerName)
 		if err != nil {
 			return errgo.Notef(err, "fail to send signal to container")
 		}
-		fmt.Printf("-----> Sending signal '%v' to '%v' container.\n", signal, container)
+		fmt.Printf("-----> Sent signal '%v' to '%v' container.\n", signal, containerName)
 	}
 	return nil
 }

--- a/apps/sendsignal.go
+++ b/apps/sendsignal.go
@@ -7,9 +7,10 @@ import (
 	"gopkg.in/errgo.v1"
 
 	"github.com/Scalingo/cli/config"
+	"github.com/Scalingo/go-scalingo/v6"
 )
 
-func SendSignal(ctx context.Context, app string, signal string, containerNames []string) error {
+func SendSignal(ctx context.Context, appName string, signal string, containerNames []string) error {
 	if len(containerNames) == 0 {
 		return errgo.New("at least one container name should be given")
 	}
@@ -18,8 +19,24 @@ func SendSignal(ctx context.Context, app string, signal string, containerNames [
 		return errgo.Notef(err, "fail to get Scalingo client to send signal to application containers")
 	}
 
+	containers, err := c.AppsContainersPs(ctx, appName)
+	if err != nil {
+		return errgo.Notef(err, "fail to list the application containers to get the ID of the container to stop")
+	}
+
 	for _, containerName := range containerNames {
-		err := c.ContainersSendSignal(ctx, app, signal, containerName)
+		var containerToStop *scalingo.Container
+		for _, container := range containers {
+			if container.Label == containerName {
+				containerToStop = &container
+				break
+			}
+		}
+		if containerToStop == nil {
+			return fmt.Errorf("The container '%s' does not exist", containerName)
+		}
+
+		err := c.ContainersSendSignal(ctx, appName, signal, containerToStop.ID)
 		if err != nil {
 			return errgo.Notef(err, "fail to send signal to container")
 		}

--- a/apps/sendsignal.go
+++ b/apps/sendsignal.go
@@ -2,63 +2,35 @@ package apps
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"gopkg.in/errgo.v1"
 
 	"github.com/Scalingo/cli/config"
+	"github.com/Scalingo/cli/io"
 	"github.com/Scalingo/go-scalingo/v6"
+	"github.com/Scalingo/go-utils/errors"
 )
 
-func isContainerInList(containers []scalingo.Container, containerToCheck scalingo.Container) bool {
-	for _, container := range containers {
-		if container.ID == containerToCheck.ID {
-			return true
-		}
-	}
-	return false
-}
-
-func keepUniqueContainersWithPrefixes(containers []scalingo.Container, prefixes []string) []scalingo.Container {
-	containersToStop := make([]scalingo.Container, 0)
-
-	for _, prefix := range prefixes {
-		hasMatched := false
-		for _, container := range containers {
-			if strings.HasPrefix(container.Label, prefix) && !isContainerInList(containersToStop, container) {
-				containersToStop = append(containersToStop, container)
-				hasMatched = true
-			}
-		}
-		if !hasMatched {
-			fmt.Printf("-----X The prefix '%v' did not match any container\n", prefix)
-		}
-	}
-
-	return containersToStop
-}
-
-func keepUniqueContainersWithNames(containers []scalingo.Container, names []string) []scalingo.Container {
-	containersToStop := make([]scalingo.Container, 0)
+func keepUniqueContainersWithNames(containers []scalingo.Container, names []string) map[string]scalingo.Container {
+	containersToKill := map[string]scalingo.Container{}
 
 	for _, name := range names {
 		hasMatched := false
 		for _, container := range containers {
-			if container.Label == name && !isContainerInList(containersToStop, container) {
-				containersToStop = append(containersToStop, container)
+			if container.Label == name {
+				containersToKill[container.ID] = container
 				hasMatched = true
 			}
 		}
 		if !hasMatched {
-			fmt.Printf("-----X The name '%v' did not match any container\n", name)
+			io.Statusf("The name '%v' did not match any container\n", name)
 		}
 	}
 
-	return containersToStop
+	return containersToKill
 }
 
-func SendSignal(ctx context.Context, appName string, signal string, isPrefixList bool, containerNames []string) error {
+func SendSignal(ctx context.Context, appName string, signal string, containerNames []string) error {
 	if len(containerNames) == 0 {
 		return errgo.New("at least one container name should be given")
 	}
@@ -73,22 +45,19 @@ func SendSignal(ctx context.Context, appName string, signal string, isPrefixList
 
 	containers, err := c.AppsContainersPs(ctx, appName)
 	if err != nil {
-		return errgo.Notef(err, "fail to list the application containers to get the ID of the container to stop")
+		return errgo.Notef(err, "fail to list the application containers to get the ID of the container to send the signal")
 	}
 
-	var containersToKill []scalingo.Container
-	if isPrefixList {
-		containersToKill = keepUniqueContainersWithPrefixes(containers, containerNames)
-	} else {
-		containersToKill = keepUniqueContainersWithNames(containers, containerNames)
-	}
+	containersToKill := keepUniqueContainersWithNames(containers, containerNames)
 
 	for _, container := range containersToKill {
 		err := c.ContainersKill(ctx, appName, signal, container.ID)
 		if err != nil {
-			return errgo.Notef(err, "fail to send signal to container")
+			rootError := errors.RootCause(err)
+			io.Statusf("Fail to send signal to container '%v' because of: %v\n", container.Label, rootError)
+			continue
 		}
-		fmt.Printf("-----> Sent signal '%v' to '%v' container.\n", signal, container.Label)
+		io.Statusf("Sent signal '%v' to '%v' container.\n", signal, container.Label)
 	}
 	return nil
 }

--- a/apps/sendsignal.go
+++ b/apps/sendsignal.go
@@ -3,6 +3,7 @@ package apps
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"gopkg.in/errgo.v1"
 
@@ -10,10 +11,61 @@ import (
 	"github.com/Scalingo/go-scalingo/v6"
 )
 
-func SendSignal(ctx context.Context, appName string, signal string, containerNames []string) error {
+func isContainerInList(containers []scalingo.Container, containerToCheck scalingo.Container) bool {
+	for _, container := range containers {
+		if container.ID == containerToCheck.ID {
+			return true
+		}
+	}
+	return false
+}
+
+func keepUniqueContainersWithPrefixes(containers []scalingo.Container, prefixes []string) []scalingo.Container {
+	containersToStop := make([]scalingo.Container, 0)
+
+	for _, prefix := range prefixes {
+		hasMatched := false
+		for _, container := range containers {
+			if strings.HasPrefix(container.Label, prefix) && !isContainerInList(containersToStop, container) {
+				containersToStop = append(containersToStop, container)
+				hasMatched = true
+			}
+		}
+		if !hasMatched {
+			fmt.Printf("-----X The prefix '%v' did not match any container\n", prefix)
+		}
+	}
+
+	return containersToStop
+}
+
+func keepUniqueContainersWithNames(containers []scalingo.Container, names []string) []scalingo.Container {
+	containersToStop := make([]scalingo.Container, 0)
+
+	for _, name := range names {
+		hasMatched := false
+		for _, container := range containers {
+			if container.Label == name && !isContainerInList(containersToStop, container) {
+				containersToStop = append(containersToStop, container)
+				hasMatched = true
+			}
+		}
+		if !hasMatched {
+			fmt.Printf("-----X The name '%v' did not match any container\n", name)
+		}
+	}
+
+	return containersToStop
+}
+
+func SendSignal(ctx context.Context, appName string, signal string, isPrefixList bool, containerNames []string) error {
 	if len(containerNames) == 0 {
 		return errgo.New("at least one container name should be given")
 	}
+	if signal == "" {
+		return errgo.New("signal must not be empty")
+	}
+
 	c, err := config.ScalingoClient(ctx)
 	if err != nil {
 		return errgo.Notef(err, "fail to get Scalingo client to send signal to application containers")
@@ -24,23 +76,19 @@ func SendSignal(ctx context.Context, appName string, signal string, containerNam
 		return errgo.Notef(err, "fail to list the application containers to get the ID of the container to stop")
 	}
 
-	for _, containerName := range containerNames {
-		var containerToStop *scalingo.Container
-		for _, container := range containers {
-			if container.Label == containerName {
-				containerToStop = &container
-				break
-			}
-		}
-		if containerToStop == nil {
-			return fmt.Errorf("The container '%s' does not exist", containerName)
-		}
+	var containersToKill []scalingo.Container
+	if isPrefixList {
+		containersToKill = keepUniqueContainersWithPrefixes(containers, containerNames)
+	} else {
+		containersToKill = keepUniqueContainersWithNames(containers, containerNames)
+	}
 
-		err := c.ContainersSendSignal(ctx, appName, signal, containerToStop.ID)
+	for _, container := range containersToKill {
+		err := c.ContainersKill(ctx, appName, signal, container.ID)
 		if err != nil {
 			return errgo.Notef(err, "fail to send signal to container")
 		}
-		fmt.Printf("-----> Sent signal '%v' to '%v' container.\n", signal, containerName)
+		fmt.Printf("-----> Sent signal '%v' to '%v' container.\n", signal, container.Label)
 	}
 	return nil
 }

--- a/apps/sendsignal.go
+++ b/apps/sendsignal.go
@@ -21,7 +21,7 @@ func keepUniqueContainersWithNames(containers []scalingo.Container, names []stri
 			}
 		}
 		if _, ok := containersToKill[name]; !ok {
-			io.Statusf("The name '%v' did not match any container.\n", name)
+			io.Errorf("The name '%v' did not match any container.\n", name)
 		}
 	}
 

--- a/apps/sendsignal.go
+++ b/apps/sendsignal.go
@@ -15,15 +15,13 @@ func keepUniqueContainersWithNames(containers []scalingo.Container, names []stri
 	containersToKill := map[string]scalingo.Container{}
 
 	for _, name := range names {
-		hasMatched := false
 		for _, container := range containers {
 			if container.Label == name {
-				containersToKill[container.ID] = container
-				hasMatched = true
+				containersToKill[name] = container
 			}
 		}
-		if !hasMatched {
-			io.Statusf("The name '%v' did not match any container\n", name)
+		if _, ok := containersToKill[name]; !ok {
+			io.Statusf("The name '%v' did not match any container.\n", name)
 		}
 	}
 
@@ -54,7 +52,7 @@ func SendSignal(ctx context.Context, appName string, signal string, containerNam
 		err := c.ContainersKill(ctx, appName, signal, container.ID)
 		if err != nil {
 			rootError := errors.RootCause(err)
-			io.Statusf("Fail to send signal to container '%v' because of: %v\n", container.Label, rootError)
+			io.Errorf("Fail to send signal to container '%v' because of: %v\n", container.Label, rootError)
 			continue
 		}
 		io.Statusf("Sent signal '%v' to '%v' container.\n", signal, container.Label)

--- a/apps/sendsignal.go
+++ b/apps/sendsignal.go
@@ -1,0 +1,29 @@
+package apps
+
+import (
+	"context"
+	"fmt"
+
+	"gopkg.in/errgo.v1"
+
+	"github.com/Scalingo/cli/config"
+)
+
+func SendSignal(ctx context.Context, app string, signal string, args []string) error {
+	if len(args) == 0 {
+		return errgo.New("at least one container name should be given")
+	}
+	c, err := config.ScalingoClient(ctx)
+	if err != nil {
+		return errgo.Notef(err, "fail to get Scalingo client to send signal to application containers")
+	}
+
+	for _, container := range args {
+		err := c.AppsContainersSendSignal(ctx, app, signal, container)
+		if err != nil {
+			return errgo.Notef(err, "fail to send signal to container")
+		}
+		fmt.Printf("-----> Sending signal '%v' to '%v' container.\n", signal, container)
+	}
+	return nil
+}

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -128,6 +128,7 @@ var (
 		&psCommand,
 		&scaleCommand,
 		&RestartCommand,
+		&sendSignalCommand,
 
 		// Routing Settings
 		&forceHTTPSCommand,

--- a/cmd/sendsignal.go
+++ b/cmd/sendsignal.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/urfave/cli/v2"
+	"gopkg.in/errgo.v1"
 
 	"github.com/Scalingo/cli/apps"
 	"github.com/Scalingo/cli/cmd/autocomplete"
@@ -24,7 +25,10 @@ var (
 		Action: func(c *cli.Context) error {
 			currentApp := detect.CurrentApp(c)
 			if c.Args().Len() == 0 {
-				cli.ShowCommandHelp(c, "send-signal")
+				err := cli.ShowCommandHelp(c, "send-signal")
+				if err != nil {
+					return errgo.Notef(err, "fail to show command helper")
+				}
 				return nil
 			}
 
@@ -36,7 +40,7 @@ var (
 			return nil
 		},
 		BashComplete: func(c *cli.Context) {
-			autocomplete.CmdFlagsAutoComplete(c, "send-signal")
+			_ = autocomplete.CmdFlagsAutoComplete(c, "send-signal")
 		},
 	}
 )

--- a/cmd/sendsignal.go
+++ b/cmd/sendsignal.go
@@ -18,12 +18,13 @@ var (
 		Usage:    "Send SIGUSR1 or SIGUSR2 to your application containers",
 		Flags: []cli.Flag{&appFlag,
 			&cli.StringFlag{Name: "signal", Aliases: []string{"s"}, Usage: "signal to send to the container", Required: true},
-			&cli.BoolFlag{Name: "prefix", Aliases: []string{"p"}, Usage: "indicates if the list of arguments represents a list of prefixes"},
+			&cli.BoolFlag{Name: "is-prefix-list", Aliases: []string{"p"}, Usage: "indicates if the list of arguments represents a list of prefixes"},
 		},
 		Description: `Send SIGUSR1 or SIGUSR2 to your application containers
 	Example
 	  'scalingo --app my-app send-signal --signal SIGUSR1 web-1'
-	  'scalingo --app my-app send-signal --signal SIGUSR2 web-1 web-2'`,
+	  'scalingo --app my-app send-signal --signal SIGUSR2 web-1 web-2'
+	  'scalingo --app my-app send-signal --signal SIGUSR1 -p web worker'`,
 		Action: func(c *cli.Context) error {
 			currentApp := detect.CurrentApp(c)
 			if c.Args().Len() == 0 {

--- a/cmd/sendsignal.go
+++ b/cmd/sendsignal.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"github.com/urfave/cli/v2"
+
+	"github.com/Scalingo/cli/apps"
+	"github.com/Scalingo/cli/cmd/autocomplete"
+	"github.com/Scalingo/cli/detect"
+	"github.com/Scalingo/go-utils/errors"
+)
+
+var (
+	sendSignalCommand = cli.Command{
+		Name:     "send-signal",
+		Category: "App Management",
+		Usage:    "Send SIGUSR1/2 to your application containers",
+		Flags: []cli.Flag{&appFlag,
+			&cli.StringFlag{Name: "signal", Aliases: []string{"s"}, Usage: "signal to send to the container"},
+		},
+		Description: `Send SIGUSR1/2 to your application containers
+	Example
+	  'scalingo --app my-app send-signal --signal SIGUSR1 web-1'`,
+		Action: func(c *cli.Context) error {
+			currentApp := detect.CurrentApp(c)
+			if c.Args().Len() == 0 {
+				cli.ShowCommandHelp(c, "send-signal")
+				return nil
+			}
+
+			err := apps.SendSignal(c.Context, currentApp, c.String("signal"), c.Args().Slice())
+			if err != nil {
+				rootError := errors.RootCause(err)
+				errorQuit(rootError)
+			}
+			return nil
+		},
+		BashComplete: func(c *cli.Context) {
+			autocomplete.CmdFlagsAutoComplete(c, "send-signal")
+		},
+	}
+)

--- a/cmd/sendsignal.go
+++ b/cmd/sendsignal.go
@@ -13,10 +13,12 @@ import (
 var (
 	sendSignalCommand = cli.Command{
 		Name:     "send-signal",
+		Aliases:  []string{"kill"},
 		Category: "App Management",
 		Usage:    "Send SIGUSR1 or SIGUSR2 to your application containers",
 		Flags: []cli.Flag{&appFlag,
-			&cli.StringFlag{Name: "signal", Aliases: []string{"s"}, Usage: "signal to send to the container"},
+			&cli.StringFlag{Name: "signal", Aliases: []string{"s"}, Usage: "signal to send to the container", Required: true},
+			&cli.BoolFlag{Name: "prefix", Aliases: []string{"p"}, Usage: "indicates if the list of arguments represents a list of prefixes"},
 		},
 		Description: `Send SIGUSR1 or SIGUSR2 to your application containers
 	Example
@@ -32,7 +34,7 @@ var (
 				return nil
 			}
 
-			err := apps.SendSignal(c.Context, currentApp, c.String("signal"), c.Args().Slice())
+			err := apps.SendSignal(c.Context, currentApp, c.String("signal"), c.Bool("prefix"), c.Args().Slice())
 			if err != nil {
 				rootError := errors.RootCause(err)
 				errorQuit(rootError)

--- a/cmd/sendsignal.go
+++ b/cmd/sendsignal.go
@@ -19,7 +19,8 @@ var (
 		},
 		Description: `Send SIGUSR1/2 to your application containers
 	Example
-	  'scalingo --app my-app send-signal --signal SIGUSR1 web-1'`,
+	  'scalingo --app my-app send-signal --signal SIGUSR1 web-1'
+	  'scalingo --app my-app send-signal --signal SIGUSR2 web-1 web-2'`,
 		Action: func(c *cli.Context) error {
 			currentApp := detect.CurrentApp(c)
 			if c.Args().Len() == 0 {

--- a/cmd/sendsignal.go
+++ b/cmd/sendsignal.go
@@ -14,11 +14,11 @@ var (
 	sendSignalCommand = cli.Command{
 		Name:     "send-signal",
 		Category: "App Management",
-		Usage:    "Send SIGUSR1/2 to your application containers",
+		Usage:    "Send SIGUSR1 or SIGUSR2 to your application containers",
 		Flags: []cli.Flag{&appFlag,
 			&cli.StringFlag{Name: "signal", Aliases: []string{"s"}, Usage: "signal to send to the container"},
 		},
-		Description: `Send SIGUSR1/2 to your application containers
+		Description: `Send SIGUSR1 or SIGUSR2 to your application containers
 	Example
 	  'scalingo --app my-app send-signal --signal SIGUSR1 web-1'
 	  'scalingo --app my-app send-signal --signal SIGUSR2 web-1 web-2'`,

--- a/cmd/sendsignal.go
+++ b/cmd/sendsignal.go
@@ -18,13 +18,11 @@ var (
 		Usage:    "Send SIGUSR1 or SIGUSR2 to your application containers",
 		Flags: []cli.Flag{&appFlag,
 			&cli.StringFlag{Name: "signal", Aliases: []string{"s"}, Usage: "signal to send to the container", Required: true},
-			&cli.BoolFlag{Name: "is-prefix-list", Aliases: []string{"p"}, Usage: "indicates if the list of arguments represents a list of prefixes"},
 		},
 		Description: `Send SIGUSR1 or SIGUSR2 to your application containers
 	Example
 	  'scalingo --app my-app send-signal --signal SIGUSR1 web-1'
-	  'scalingo --app my-app send-signal --signal SIGUSR2 web-1 web-2'
-	  'scalingo --app my-app send-signal --signal SIGUSR1 -p web worker'`,
+	  'scalingo --app my-app send-signal --signal SIGUSR2 web-1 web-2'`,
 		Action: func(c *cli.Context) error {
 			currentApp := detect.CurrentApp(c)
 			if c.Args().Len() == 0 {
@@ -35,7 +33,7 @@ var (
 				return nil
 			}
 
-			err := apps.SendSignal(c.Context, currentApp, c.String("signal"), c.Bool("prefix"), c.Args().Slice())
+			err := apps.SendSignal(c.Context, currentApp, c.String("signal"), c.Args().Slice())
 			if err != nil {
 				rootError := errors.RootCause(err)
 				errorQuit(rootError)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
 	github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5
-	github.com/Scalingo/go-scalingo/v6 v6.0.1
+	github.com/Scalingo/go-scalingo/v6 v6.1.0
 	github.com/Scalingo/go-utils/errors v1.1.1
 	github.com/Scalingo/go-utils/logger v1.2.0
 	github.com/Scalingo/go-utils/retry v1.1.1
@@ -42,7 +42,7 @@ require (
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/go-git/go-billy/v5 v5.3.1 // indirect
-	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
+	github.com/golang-jwt/jwt/v4 v4.4.3 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 h1:ra2OtmuW0A
 github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4/go.mod h1:UBYPn8k0D56RtnR8RFQMjmh4KrZzWJ5o7Z9SYjossQ8=
 github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5 h1:VauE2GcJNZFun2Och6tIT2zJZK1v6jxALQDA9BIji/E=
 github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5/go.mod h1:gxOHeajFfvGQh/fxlC8oOKBe23xnnJTif00IFFbiT+o=
-github.com/Scalingo/go-scalingo/v6 v6.0.1 h1:06nvdTk1OaQYRvcYhMfI6v8n4EJ5hqfWZ58uZbqBLgo=
-github.com/Scalingo/go-scalingo/v6 v6.0.1/go.mod h1:R69yPaXHkZ4iWTpwcV1OZ2t11wEQX+HOoqrj+qRaoGs=
+github.com/Scalingo/go-scalingo/v6 v6.1.0 h1:e7LwOy3ePVRsMDu1V4rDqWgCXaE55hm9dRLj8i4qwf4=
+github.com/Scalingo/go-scalingo/v6 v6.1.0/go.mod h1:Y3QByF4s5i3lpJh87c5FEkSN07CWomN5FPt0X/Qzg0I=
 github.com/Scalingo/go-utils/errors v1.1.1 h1:G7zypaDBj0O6QFvX0xL5dMDXbiBgq+3KKuodldtOpg0=
 github.com/Scalingo/go-utils/errors v1.1.1/go.mod h1:gsnGOMma5x3CSgPb8i5eMuHcKi3RvTJ9dWPNRev161c=
 github.com/Scalingo/go-utils/logger v1.2.0 h1:E3jtaoRxpIsFcZu/jsvWew8ttUAwKUYQufdPqGYp7EU=

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/go-git/go-git-fixtures/v4 v4.3.1 h1:y5z6dd3qi8Hl+stezc8p3JxDkoTRqMAlK
 github.com/go-git/go-git-fixtures/v4 v4.3.1/go.mod h1:8LHG1a3SRW71ettAD/jW13h8c6AqjVSeL11RAdgaqpo=
 github.com/go-git/go-git/v5 v5.5.1 h1:5vtv2TB5PM/gPM+EvsHJ16hJh4uAkdGcKilcwY7FYwo=
 github.com/go-git/go-git/v5 v5.5.1/go.mod h1:uz5PQ3d0gz7mSgzZhSJToM6ALPaKCdSnl58/Xb5hzr8=
-github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
-github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.4.3 h1:Hxl6lhQFj4AnOX6MLrsCb/+7tCj7DxP7VA+2rDIq5AU=
+github.com/golang-jwt/jwt/v4 v4.4.3/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/google/go-cmp v0.2.1-0.20190312032427-6f77996f0c42/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/vendor/github.com/Scalingo/go-scalingo/v6/CHANGELOG.md
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## To Be Released
 
+## 6.1.0
+
+* feat(events): Add Detached field for EventRun [#292](https://github.com/Scalingo/go-scalingo/pull/292)
+* chore(deps): bump github.com/golang-jwt/jwt/v4 from 4.4.2 to 4.4.3
+* feat(send-signal): new function `ContainersKill` to request the send-signal api's endpoint [#295](https://github.com/Scalingo/go-scalingo/pull/295)
+
 ## 6.0.1
 
 * chore(deps): bump github.com/stretchr/testify from 1.8.0 to 1.8.1

--- a/vendor/github.com/Scalingo/go-scalingo/v6/README.md
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/README.md
@@ -1,6 +1,6 @@
 [ ![Codeship Status for Scalingo/go-scalingo](https://app.codeship.com/projects/cf518dc0-0034-0136-d6b3-5a0245e77f67/status?branch=master)](https://app.codeship.com/projects/279805)
 
-# Go client for Scalingo API v6.0.1
+# Go client for Scalingo API v6.1.0
 
 This repository is the Go client for the [Scalingo APIs](https://developers.scalingo.com/).
 
@@ -81,10 +81,10 @@ Commit, tag and create a new release:
 
 ```sh
 git add CHANGELOG.md README.md version.go
-git commit -m "Bump v6.0.1"
-git tag v6.0.1
-git push origin master v6.0.1
-gh release create v6.0.1
+git commit -m "Bump v6.1.0"
+git tag v6.1.0
+git push origin master v6.1.0
+gh release create v6.1.0
 ```
 
 The title of the release should be the version number and the text of the

--- a/vendor/github.com/Scalingo/go-scalingo/v6/apps.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/apps.go
@@ -275,6 +275,21 @@ func (c *Client) AppsContainersPs(ctx context.Context, app string) ([]Container,
 	return containersRes.Containers, nil
 }
 
+func (c *Client) AppsContainersSendSignal(ctx context.Context, app string, signal string, container string) error {
+	req := &httpclient.APIRequest{
+		Method:   "POST",
+		Endpoint: "/apps/" + app + "/containers/" + container + "/kill",
+		Params:   map[string]interface{}{"signal": signal},
+		Expected: httpclient.Statuses{204},
+	}
+	err := c.ScalingoAPI().DoRequest(ctx, req, nil)
+	if err != nil {
+		return errgo.Notef(err, "fail to execute the POST request to send signal to container")
+	}
+
+	return nil
+}
+
 func (c *Client) AppsContainerTypes(ctx context.Context, app string) ([]ContainerType, error) {
 	var containerTypesRes AppsContainerTypesRes
 	req := &httpclient.APIRequest{

--- a/vendor/github.com/Scalingo/go-scalingo/v6/apps.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/apps.go
@@ -275,21 +275,6 @@ func (c *Client) AppsContainersPs(ctx context.Context, app string) ([]Container,
 	return containersRes.Containers, nil
 }
 
-func (c *Client) AppsContainersSendSignal(ctx context.Context, app string, signal string, container string) error {
-	req := &httpclient.APIRequest{
-		Method:   "POST",
-		Endpoint: "/apps/" + app + "/containers/" + container + "/kill",
-		Params:   map[string]interface{}{"signal": signal},
-		Expected: httpclient.Statuses{204},
-	}
-	err := c.ScalingoAPI().DoRequest(ctx, req, nil)
-	if err != nil {
-		return errgo.Notef(err, "fail to execute the POST request to send signal to container")
-	}
-
-	return nil
-}
-
 func (c *Client) AppsContainerTypes(ctx context.Context, app string) ([]ContainerType, error) {
 	var containerTypesRes AppsContainerTypesRes
 	req := &httpclient.APIRequest{

--- a/vendor/github.com/Scalingo/go-scalingo/v6/container.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/container.go
@@ -43,3 +43,18 @@ func (c *Client) ContainersStop(ctx context.Context, appName, containerID string
 
 	return nil
 }
+
+func (c *Client) ContainersKill(ctx context.Context, app string, signal string, containerID string) error {
+	req := &httpclient.APIRequest{
+		Method:   "POST",
+		Endpoint: "/apps/" + app + "/containers/" + containerID + "/kill",
+		Params:   map[string]interface{}{"signal": signal},
+		Expected: httpclient.Statuses{204},
+	}
+	err := c.ScalingoAPI().DoRequest(ctx, req, nil)
+	if err != nil {
+		return errgo.Notef(err, "fail to execute the POST request to send signal to a container")
+	}
+
+	return nil
+}

--- a/vendor/github.com/Scalingo/go-scalingo/v6/events_structs.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/events_structs.go
@@ -223,12 +223,17 @@ type EventRunType struct {
 }
 
 func (ev *EventRunType) String() string {
-	return fmt.Sprintf("one-off container with command '%s'", ev.TypeData.Command)
+	detached := ""
+	if ev.TypeData.Detached {
+		detached = "detached "
+	}
+	return fmt.Sprintf("%sone-off container with command '%s'", ev.TypeData.Command, detached)
 }
 
 type EventRunTypeData struct {
 	Command    string `json:"command"`
 	AuditLogID string `json:"audit_log_id"`
+	Detached   bool   `json:"detached"`
 }
 
 type EventNewDomainType struct {

--- a/vendor/github.com/Scalingo/go-scalingo/v6/version.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "6.0.1"
+var Version = "6.1.0"

--- a/vendor/github.com/golang-jwt/jwt/v4/README.md
+++ b/vendor/github.com/golang-jwt/jwt/v4/README.md
@@ -54,9 +54,9 @@ import "github.com/golang-jwt/jwt/v4"
 
 See [the project documentation](https://pkg.go.dev/github.com/golang-jwt/jwt/v4) for examples of usage:
 
-* [Simple example of parsing and validating a token](https://pkg.go.dev/github.com/golang-jwt/jwt#example-Parse-Hmac)
-* [Simple example of building and signing a token](https://pkg.go.dev/github.com/golang-jwt/jwt#example-New-Hmac)
-* [Directory of Examples](https://pkg.go.dev/github.com/golang-jwt/jwt#pkg-examples)
+* [Simple example of parsing and validating a token](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#example-Parse-Hmac)
+* [Simple example of building and signing a token](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#example-New-Hmac)
+* [Directory of Examples](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#pkg-examples)
 
 ## Extensions
 
@@ -96,7 +96,7 @@ A token is simply a JSON object that is signed by its author. this tells you exa
 * The author of the token was in the possession of the signing secret
 * The data has not been modified since it was signed
 
-It's important to know that JWT does not provide encryption, which means anyone who has access to the token can read its contents. If you need to protect (encrypt) the data, there is a companion spec, `JWE`, that provides this functionality. JWE is currently outside the scope of this library.
+It's important to know that JWT does not provide encryption, which means anyone who has access to the token can read its contents. If you need to protect (encrypt) the data, there is a companion spec, `JWE`, that provides this functionality. The companion project https://github.com/golang-jwt/jwe aims at a (very) experimental implementation of the JWE standard.
 
 ### Choosing a Signing Method
 
@@ -110,10 +110,10 @@ Asymmetric signing methods, such as RSA, use different keys for signing and veri
 
 Each signing method expects a different object type for its signing keys. See the package documentation for details. Here are the most common ones:
 
-* The [HMAC signing method](https://pkg.go.dev/github.com/golang-jwt/jwt#SigningMethodHMAC) (`HS256`,`HS384`,`HS512`) expect `[]byte` values for signing and validation
-* The [RSA signing method](https://pkg.go.dev/github.com/golang-jwt/jwt#SigningMethodRSA) (`RS256`,`RS384`,`RS512`) expect `*rsa.PrivateKey` for signing and `*rsa.PublicKey` for validation
-* The [ECDSA signing method](https://pkg.go.dev/github.com/golang-jwt/jwt#SigningMethodECDSA) (`ES256`,`ES384`,`ES512`) expect `*ecdsa.PrivateKey` for signing and `*ecdsa.PublicKey` for validation
-* The [EdDSA signing method](https://pkg.go.dev/github.com/golang-jwt/jwt#SigningMethodEd25519) (`Ed25519`) expect `ed25519.PrivateKey` for signing and `ed25519.PublicKey` for validation
+* The [HMAC signing method](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#SigningMethodHMAC) (`HS256`,`HS384`,`HS512`) expect `[]byte` values for signing and validation
+* The [RSA signing method](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#SigningMethodRSA) (`RS256`,`RS384`,`RS512`) expect `*rsa.PrivateKey` for signing and `*rsa.PublicKey` for validation
+* The [ECDSA signing method](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#SigningMethodECDSA) (`ES256`,`ES384`,`ES512`) expect `*ecdsa.PrivateKey` for signing and `*ecdsa.PublicKey` for validation
+* The [EdDSA signing method](https://pkg.go.dev/github.com/golang-jwt/jwt/v4#SigningMethodEd25519) (`Ed25519`) expect `ed25519.PrivateKey` for signing and `ed25519.PublicKey` for validation
 
 ### JWT and OAuth
 
@@ -131,7 +131,7 @@ This library uses descriptive error messages whenever possible. If you are not g
 
 ## More
 
-Documentation can be found [on pkg.go.dev](https://pkg.go.dev/github.com/golang-jwt/jwt).
+Documentation can be found [on pkg.go.dev](https://pkg.go.dev/github.com/golang-jwt/jwt/v4).
 
 The command line utility included in this project (cmd/jwt) provides a straightforward example of token creation and parsing as well as a useful tool for debugging your own integration. You'll also find several implementation examples in the documentation.
 

--- a/vendor/github.com/golang-jwt/jwt/v4/claims.go
+++ b/vendor/github.com/golang-jwt/jwt/v4/claims.go
@@ -265,9 +265,5 @@ func verifyIss(iss string, cmp string, required bool) bool {
 	if iss == "" {
 		return !required
 	}
-	if subtle.ConstantTimeCompare([]byte(iss), []byte(cmp)) != 0 {
-		return true
-	} else {
-		return false
-	}
+	return subtle.ConstantTimeCompare([]byte(iss), []byte(cmp)) != 0
 }

--- a/vendor/github.com/golang-jwt/jwt/v4/parser.go
+++ b/vendor/github.com/golang-jwt/jwt/v4/parser.go
@@ -42,6 +42,13 @@ func (p *Parser) Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
 	return p.ParseWithClaims(tokenString, MapClaims{}, keyFunc)
 }
 
+// ParseWithClaims parses, validates, and verifies like Parse, but supplies a default object implementing the Claims
+// interface. This provides default values which can be overridden and allows a caller to use their own type, rather
+// than the default MapClaims implementation of Claims.
+//
+// Note: If you provide a custom claim implementation that embeds one of the standard claims (such as RegisteredClaims),
+// make sure that a) you either embed a non-pointer version of the claims or b) if you are using a pointer, allocate the
+// proper memory for it before passing in the overall claims, otherwise you might run into a panic.
 func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
 	token, parts, err := p.ParseUnverified(tokenString, claims)
 	if err != nil {

--- a/vendor/github.com/golang-jwt/jwt/v4/token.go
+++ b/vendor/github.com/golang-jwt/jwt/v4/token.go
@@ -99,6 +99,11 @@ func Parse(tokenString string, keyFunc Keyfunc, options ...ParserOption) (*Token
 	return NewParser(options...).Parse(tokenString, keyFunc)
 }
 
+// ParseWithClaims is a shortcut for NewParser().ParseWithClaims().
+//
+// Note: If you provide a custom claim implementation that embeds one of the standard claims (such as RegisteredClaims),
+// make sure that a) you either embed a non-pointer version of the claims or b) if you are using a pointer, allocate the
+// proper memory for it before passing in the overall claims, otherwise you might run into a panic.
 func ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc, options ...ParserOption) (*Token, error) {
 	return NewParser(options...).ParseWithClaims(tokenString, claims, keyFunc)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -30,7 +30,7 @@ github.com/ProtonMail/go-crypto/openpgp/s2k
 # github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5
 ## explicit; go 1.13
 github.com/ScaleFT/sshkeys
-# github.com/Scalingo/go-scalingo/v6 v6.0.1
+# github.com/Scalingo/go-scalingo/v6 v6.1.0
 ## explicit; go 1.17
 github.com/Scalingo/go-scalingo/v6
 github.com/Scalingo/go-scalingo/v6/billing

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -160,7 +160,7 @@ github.com/go-git/go-git/v5/utils/merkletrie/index
 github.com/go-git/go-git/v5/utils/merkletrie/internal/frame
 github.com/go-git/go-git/v5/utils/merkletrie/noder
 github.com/go-git/go-git/v5/utils/sync
-# github.com/golang-jwt/jwt/v4 v4.4.2
+# github.com/golang-jwt/jwt/v4 v4.4.3
 ## explicit; go 1.16
 github.com/golang-jwt/jwt/v4
 # github.com/golang/mock v1.6.0


### PR DESCRIPTION
- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md

```
» ./scalingo help send-signal                                                                                                                                                     
NAME:
   scalingo send-signal - Send SIGUSR1 or SIGUSR2 to your application containers

USAGE:
   scalingo send-signal [command options] [arguments...]

CATEGORY:
   App Management

DESCRIPTION:
   Send SIGUSR1 or SIGUSR2 to your application containers
     Example
       'scalingo --app my-app send-signal --signal SIGUSR1 web-1'
       'scalingo --app my-app send-signal --signal SIGUSR2 web-1 web-2'

OPTIONS:
   --app value, -a value     Name of the current app
   --signal value, -s value  signal to send to the container
   --region value            Name of the region to use
   --help, -h                show help (default: false)
```

Fix #832 