### PR TITLE
fix(send-signal): remove trailing whitespace when container not found

### DIFF
--- a/apps/sendsignal.go
+++ b/apps/sendsignal.go
@@ -25,7 +25,7 @@ func keepUniqueContainersWithType(containers []scalingo.Container, typeName stri
 		}
 	}
 	if !hasMatched {
-		return containersToKill, errgo.Newf("'%v' did not match any container\n", typeName)
+		return containersToKill, errgo.Newf("'%v' did not match any container", typeName)
 	}
 
 	return containersToKill, nil


### PR DESCRIPTION
Sorry for this pr, I didn't notice that io.Error print a new line.

Fix #844

- [ ] Add a changelog entry in the section "To Be Released" of CHANGELOG.md
