### PR TITLE
chore(deps): bump github.com/ScaleFT/sshkeys from v0.0.0-20200327173127-6142f742bca5 to v1.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6
-	github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5
+	github.com/ScaleFT/sshkeys v1.2.0
 	github.com/Scalingo/go-scalingo/v6 v6.1.0
 	github.com/Scalingo/go-utils/errors v1.1.1
 	github.com/Scalingo/go-utils/logger v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4 h1:ra2OtmuW0AE5csawV4YXMNGNQQXvLRps3z2Z59OPO+I=
 github.com/ProtonMail/go-crypto v0.0.0-20221026131551-cf6655e29de4/go.mod h1:UBYPn8k0D56RtnR8RFQMjmh4KrZzWJ5o7Z9SYjossQ8=
-github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5 h1:VauE2GcJNZFun2Och6tIT2zJZK1v6jxALQDA9BIji/E=
-github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5/go.mod h1:gxOHeajFfvGQh/fxlC8oOKBe23xnnJTif00IFFbiT+o=
+github.com/ScaleFT/sshkeys v1.2.0 h1:5BRp6rTVIhJzXT3VcUQrKgXR8zWA3sOsNeuyW15WUA8=
+github.com/ScaleFT/sshkeys v1.2.0/go.mod h1:gxOHeajFfvGQh/fxlC8oOKBe23xnnJTif00IFFbiT+o=
 github.com/Scalingo/go-scalingo/v6 v6.1.0 h1:e7LwOy3ePVRsMDu1V4rDqWgCXaE55hm9dRLj8i4qwf4=
 github.com/Scalingo/go-scalingo/v6 v6.1.0/go.mod h1:Y3QByF4s5i3lpJh87c5FEkSN07CWomN5FPt0X/Qzg0I=
 github.com/Scalingo/go-utils/errors v1.1.1 h1:G7zypaDBj0O6QFvX0xL5dMDXbiBgq+3KKuodldtOpg0=

--- a/vendor/github.com/ScaleFT/sshkeys/marshal.go
+++ b/vendor/github.com/ScaleFT/sshkeys/marshal.go
@@ -11,8 +11,8 @@ import (
 	"encoding/asn1"
 	"encoding/pem"
 	"fmt"
+	"math"
 	"math/big"
-	mrand "math/rand"
 
 	"github.com/dchest/bcrypt_pbkdf"
 	"golang.org/x/crypto/ed25519"
@@ -180,7 +180,14 @@ func marshalOpenssh(pk interface{}, opts *MarshalOptions) ([]byte, error) {
 		blocksize = aes.BlockSize
 	}
 
-	check := mrand.Uint32()
+	// Get a crypto rand in the range [0, uint32-max]
+	randnum, err := rand.Int(rand.Reader, big.NewInt(math.MaxUint32+1))
+	if err != nil {
+		return nil, fmt.Errorf("sshkeys: failed to get random number: %w", err)
+	}
+	// Convert it to uint32. As the content was within uint32 limits, nothing should be lost
+	check := uint32(randnum.Uint64())
+
 	pk1 := opensshKey{
 		Check1: check,
 		Check2: check,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -28,7 +28,7 @@ github.com/ProtonMail/go-crypto/openpgp/internal/ecc
 github.com/ProtonMail/go-crypto/openpgp/internal/encoding
 github.com/ProtonMail/go-crypto/openpgp/packet
 github.com/ProtonMail/go-crypto/openpgp/s2k
-# github.com/ScaleFT/sshkeys v0.0.0-20200327173127-6142f742bca5
+# github.com/ScaleFT/sshkeys v1.2.0
 ## explicit; go 1.13
 github.com/ScaleFT/sshkeys
 # github.com/Scalingo/go-scalingo/v6 v6.1.0


### PR DESCRIPTION
- [ ] Add a changelog entry in the section "To Be Released" of CHANGELOG.md