### PR TITLE
fix(cli-build) Compile the CLI statically to prevent GLIBC incompatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,7 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CGO_ENABLED: 0
 
   releases-windows:
     needs: tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### To be Released
 
+* fix(cli-build) Compile the CLI statically to prevent GLIBC incompatibility [#863](https://github.com/Scalingo/cli/pull/863)
+
 ### 1.27.0
 
 * fix(commands): display help usage message if needed [#835](https://github.com/Scalingo/cli/pull/835)


### PR DESCRIPTION
Fix #862

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md