### PR TITLE
fix(commands): brought back --help command

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -61,9 +61,9 @@ Example{{with $length := len .Examples}}{{if ne 1 $length}}s{{end}}{{end}}{{ ran
 
 func (cmds *AppCommands) addCommand(cmd Command) {
 	cmds.commands = append(cmds.commands, cmd.Command)
-	// I don't really understand the official documentation about this field.
-	// But setting it to true enables the display of the help usage message when `cli.ShowCommandHelp` is called. Without this setting, the call to `cli.ShowCommandHelp` displays a "No help topic for command" error message.
-	cmd.Command.HideHelp = true
+
+	// This argument disables the global help command, but doesn't disable the flag.
+	cmd.Command.HideHelpCommand = true
 
 	// Global commands are simply added to the list of commands
 	if cmd.Global {


### PR DESCRIPTION
This PR fixes #865 
It fixes the regression introduced with #835 

This is the line that disabled the `--help` flag and the floating `help` sub-command. So I've only disabled the `help` sub-command.

I wondered why the issues #834 
and
#831 

I investigated and the root problem was : when calling the `cli.ShowCommandHelp`, our command's help is not found.

urfave cli is introducing a subcommand in every command. The subcommand `help`. So we can do for example `scalingo create help` and the help should be displayed.

When the number of args is invalid, we call the command `cli.ShowCommandHelp` with our commands' name. But here is the catch.

![Pasted image 20230123142822](https://user-images.githubusercontent.com/122296171/214059837-aaf92370-6d96-4d65-ba25-4dd4c235d45b.png)

Here is the problem. In the function code : 

If our command has subcommands : it will restrict its search to the subcommands. And our command has a subcommand : `help`. If we search for `addons-add`, we will only search through "help".

I don't know if this is a design issue or our misuse, but disabling the help command will do the trick for now.