### PR TITLE
fix(backups): `backup` flag is not required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### To be Released
 
+* fix(backups): backup flag is not required
+
 ### 1.27.2
 
 * bump: go-scalingo v6.2.0

--- a/cmd/backups.go
+++ b/cmd/backups.go
@@ -60,10 +60,9 @@ var (
 		Category: "Addons",
 		Usage:    "Download a backup",
 		Flags: []cli.Flag{&appFlag, &addonFlag, &cli.StringFlag{
-			Name:     "backup",
-			Aliases:  []string{"b"},
-			Usage:    "ID of the backup to download",
-			Required: true,
+			Name:    "backup",
+			Aliases: []string{"b"},
+			Usage:   "ID of the backup to download",
 		}, &cli.StringFlag{
 			Name:    "output",
 			Aliases: []string{"o"},

--- a/cmd/backups.go
+++ b/cmd/backups.go
@@ -60,9 +60,10 @@ var (
 		Category: "Addons",
 		Usage:    "Download a backup",
 		Flags: []cli.Flag{&appFlag, &addonFlag, &cli.StringFlag{
-			Name:    "backup",
-			Aliases: []string{"b"},
-			Usage:   "ID of the backup to download",
+			Name:        "backup",
+			Aliases:     []string{"b"},
+			Usage:       "ID of the backup to download",
+			DefaultText: "last successful backup",
 		}, &cli.StringFlag{
 			Name:    "output",
 			Aliases: []string{"o"},


### PR DESCRIPTION
Bug introduced in #868.

Fix #891

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md