### PR TITLE
feat(install.sh): add arm64 architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### To be Released
 
 * feat(log-drains): add Logtail
+* feat(install.sh): add arm64 to the list of installable architectures ([PR#930](https://github.com/Scalingo/cli/pull/930))
 * chore(deps): replace `github.com/ScaleFT/sshkeys` with `golang.org/x/crypto/ssh`
 * fix(completion): fix zsh shebang reference
 

--- a/dists/install.sh
+++ b/dists/install.sh
@@ -60,6 +60,9 @@ main() {
     i686)
       arch=386
       ;;
+    aarch64)
+      arch=arm64
+      ;;
   esac
 
   while [ "$#" -gt "0" ]


### PR DESCRIPTION
Hello,

This PR adds support for the ARM64 architecture in the magic install script, since you have already been kind enough to build binaries for these processors, both for Linux and for macOS.

This will allow to quickly install the CLI on a Raspberry Pi or a Mac M1/M2! 🥳 

Thanks a lot!

## Demo

Works on Raspberry Pi with Raspberry Pi OS 64 bit:
```
joseph@raspberrypi-8go:~ $ uname -a
Linux raspberrypi-8go 6.1.19-v8+ #1637 SMP PREEMPT Tue Mar 14 11:11:47 GMT 2023 aarch64 GNU/Linux

joseph@raspberrypi-8go:~ $ curl -O https://raw.githubusercontent.com/josephpage/cli/arm64-in-install-script/dists/install.sh && bash install.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4203  100  4203    0     0   5347      0 --:--:-- --:--:-- --:--:--  5340
-----> Downloading Scalingo client...  DONE
-----> Extracting...   DONE
-----> Install Scalingo client to /usr/local/bin
       sudo required...
-----> Installation completed, the command 'scalingo' is available.
-----> Here's what's new in this version:

Changelog of the version 1.28.2

## What's Changed
* refacto(wait-operation) Fix extra space in output and make the code a bit clearer by @Soulou in https://github.com/Scalingo/cli/pull/912
* Use async one-off for database console commands by @Soulou in https://github.com/Scalingo/cli/pull/913
* Bump version 1.28.2 by @Soulou in https://github.com/Scalingo/cli/pull/914


**Full Changelog**: https://github.com/Scalingo/cli/compare/1.28.1...1.28.2

joseph@raspberrypi-8go:~ $ scalingo --version
Scalingo Client version 1.28.2
```

----
- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md
