### PR TITLE
feat: add multi architecture nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1682929865,
+        "narHash": "sha256-jxVrgnf5QNjO+XoxDxUWtN2G5xyJSGZ5SWDQFxMuHxc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f2e9a130461950270f87630b11132323706b4d91",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682929865,
-        "narHash": "sha256-jxVrgnf5QNjO+XoxDxUWtN2G5xyJSGZ5SWDQFxMuHxc=",
+        "lastModified": 1686089707,
+        "narHash": "sha256-LTNlJcru2qJ0XhlhG9Acp5KyjB774Pza3tRH0pKIb3o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f2e9a130461950270f87630b11132323706b4d91",
+        "rev": "af21c31b2a1ec5d361ed8050edd0303c31306397",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils }:
+    utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in rec {
+        packages = rec {
+          default = pkgs.buildGoModule {
+            name = "scalingo";
+
+            src = pkgs.fetchFromGitHub {
+              owner = "Scalingo";
+              repo = "cli";
+              rev = "1.28.2";
+              sha256 = "sha256-dMiOGPQ2wodVdB43Sk3GfEFYIU/W2K9DG/4hhVxb1fs=";
+            };
+
+            vendorSha256 = null;
+
+            ldflags = [ "-w" "-s" ];
+
+            preConfigure = ''
+              export HOME=$TMPDIR
+            '';
+          };
+        };
+
+        apps = rec {
+          default = utils.lib.mkApp { drv = packages.default; };
+        };
+
+        devShell = with pkgs;
+          mkShell {
+            buildInputs = [ go ];
+          };
+      });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -16,8 +16,8 @@
             src = pkgs.fetchFromGitHub {
               owner = "Scalingo";
               repo = "cli";
-              rev = "1.28.2";
-              sha256 = "sha256-dMiOGPQ2wodVdB43Sk3GfEFYIU/W2K9DG/4hhVxb1fs=";
+              rev = "1.29.1";
+              sha256 = "sha256-xBf+LIwlpauJd/0xJIQdfEa0rxph3BJPuMY4+0s+Bb4=";
             };
 
             vendorSha256 = null;


### PR DESCRIPTION
[Nix](https://nixos.org/) is a package manager, think `homebrew` on macOS or `apt` on Debian/Ubuntu. The Scalingo CLI isn't yet available in the nix repository, though there is a [pending pull request](https://github.com/NixOS/nixpkgs/pull/224858).

[Flakes](https://xeiaso.net/blog/nix-flakes-1-2022-02-21) are a newer nix feature and can run or install software directly from online sources. This pull request includes a flake for the Scalingo CLI 1.28.2 client. With only the nix package manager installed, you can run the Scalingo CLI client directly without installing anything:

```
$ nix run github:cimm/scalingo-cli/add-nix-flake#scalingo -- --version
Scalingo Client version 1.28.2
```

The command could be simplified to `nix run github:Scalingo/cli -- --version` once this pull request has been merged.

Flakes can also be used to develop and build applications without having to install development dependencies. `nix build github:cimm/scalingo-cli/add-nix-flake`, for example, builds the client in the `./results/bin` directory, even when go is not installed on the system.

Anyway, I use it daily to work on our webapps hosted at Scalingo, so it might be useful for others as well. Feel free to close the pull request if this is out of scope, no hard feelings.