### PR TITLE
feat(install.sh): verify the archive checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * feat: add database maintenance info with the new `database-maintenance-info` command ([PR#984](https://github.com/Scalingo/cli/pull/984))
 * feat: add database maintenance listing with the new `database-maintenance-list` command ([PR#982](https://github.com/Scalingo/cli/pull/982))
 * feat(addons): add maintenance windows manipulation with the new `addon-config` command ([PR#955](https://github.com/Scalingo/cli/pull/955))
+* feat(install.sh): verify the archive checksum ([PR#988](https://github.com/Scalingo/cli/pull/988))
 
 ### 1.29.1
 

--- a/dists/install.sh
+++ b/dists/install.sh
@@ -10,7 +10,7 @@ main() {
   }
 
   error() {
-    echo -en " !     $*"
+    echo -en " !     $*" >&2
   }
 
   warn() {
@@ -112,8 +112,8 @@ main() {
 
   version=$(curl --silent https://cli-dl.scalingo.com/version | tr -d ' \t\n')
   if [ -z "$version" ]; then
-    echo "-----> Fail to get the version of the CLI" >&2
-    echo "You probably have an old version of curl. Please check your curl version and update accordingly." >&2
+    error "Fail to get the version of the CLI\n"
+    error "You probably have an old version of curl. Please check your curl version and update accordingly.\n"
     exit 1
   fi
 
@@ -124,8 +124,8 @@ main() {
   status "Downloading Scalingo client...  "
   curl --silent --fail --location --output ${tmpdir}/${archive_name} ${url}
   if [ ! -f ${tmpdir}/${archive_name} ]; then
-    echo "" >&2
-    echo "-----> Fail to download the CLI archive" >&2
+    echo ""
+    error "Fail to download the CLI archive\n"
     exit 1
   fi
   echo "DONE"
@@ -147,8 +147,8 @@ main() {
 
   exe_path=${tmpdir}/${dirname}/scalingo
   if [ ! -f "$exe_path" ]; then
-    echo "" >&2
-    echo "-----> Fail to extract the CLI archive" >&2
+    echo ""
+    error "Fail to extract the CLI archive\n"
     exit 1
   fi
   echo "DONE"

--- a/dists/install.sh
+++ b/dists/install.sh
@@ -110,7 +110,7 @@ main() {
   tmpdir=$(mktemp -d /tmp/scalingo_cli_XXX)
   trap "clean_install ${tmpdir}" EXIT
 
-  version=$(curl --silent https://cli-dl.scalingo.com/version | tr -d ' \t\n')
+  version=$(curl --silent https://cli-dl.scalingo.com/version | tr --delete ' \t\n')
   if [ -z "$version" ]; then
     error "Fail to get the version of the CLI\n"
     error "You probably have an old version of curl. Please check your curl version and update accordingly.\n"
@@ -132,8 +132,8 @@ main() {
 
   status "Verifying the checksum...  "
   checksums_url="https://github.com/Scalingo/cli/releases/download/${version}/checksums.txt"
-  checksum_computed=$(sha256sum ${tmpdir}/${archive_name} | cut -d " " -f1)
-  checksum_expected=$(wget -q --output-document - $checksums_url | grep $archive_name | cut -d " " -f 1)
+  checksum_computed=$(sha256sum ${tmpdir}/${archive_name} | cut --delimiter=" " --fields=1)
+  checksum_expected=$(wget --quiet --output-document - $checksums_url | grep $archive_name | cut --delimiter=" " --fields=1)
   if [[ "$checksum_computed" != "$checksum_expected" ]]; then
     echo "INVALID"
     error "Checksums don't match ('$checksum_computed' != '$checksum_expected').\n"
@@ -162,8 +162,8 @@ main() {
 
   if [ -x "$target" -a -z "$yes_to_overwrite" ] ; then
     export DISABLE_UPDATE_CHECKER=true
-    new_version=$($exe_path --version | cut -d' ' -f4)
-    old_version=$("$target" --version | cut -d' ' -f4)
+    new_version=$($exe_path --version | cut --delimiter=' ' --fields=4)
+    old_version=$("$target" --version | cut --delimiter=' ' --fields=4)
     warn "Scalingo client is already installed (version ${old_version})\n"
 
     if ! ask "Do you want to replace it with version ${new_version}?"  ; then

--- a/dists/install.sh
+++ b/dists/install.sh
@@ -119,7 +119,7 @@ main() {
 
   dirname="scalingo_${version}_${os}_${arch}"
   archive_name="${dirname}.${ext}"
-  url=https://github.com/Scalingo/cli/releases/download/${version}/${archive_name}
+  url="https://github.com/Scalingo/cli/releases/download/${version}/${archive_name}"
 
   status "Downloading Scalingo client...  "
   curl --silent --fail --location --output ${tmpdir}/${archive_name} ${url}
@@ -129,6 +129,19 @@ main() {
     exit 1
   fi
   echo "DONE"
+
+  status "Verifying the checksum...  "
+  checksums_url="https://github.com/Scalingo/cli/releases/download/${version}/checksums.txt"
+  checksum_computed=$(sha256sum ${tmpdir}/${archive_name} | cut -d " " -f1)
+  checksum_expected=$(wget -q --output-document - $checksums_url | grep $archive_name | cut -d " " -f 1)
+  if [[ "$checksum_computed" != "$checksum_expected" ]]; then
+    echo "INVALID"
+    error "Checksums don't match ('$checksum_computed' != '$checksum_expected').\n"
+    error "You may want to retry to install the Scalingo CLI. If the problem persists, please contact our support team.\n"
+    exit 1
+  fi
+  echo "VALID"
+
   status "Extracting...   "
   tar -C "${tmpdir}" -x -f "${tmpdir}/${archive_name}"
 

--- a/dists/install.sh
+++ b/dists/install.sh
@@ -136,7 +136,7 @@ main() {
   checksum_expected=$(wget --quiet --output-document - $checksums_url | grep $archive_name | cut --delimiter=" " --fields=1)
   if [[ "$checksum_computed" != "$checksum_expected" ]]; then
     echo "INVALID"
-    error "Checksums don't match ('$checksum_computed' != '$checksum_expected').\n"
+    error "Checksums don't match.\n"
     error "You may want to retry to install the Scalingo CLI. If the problem persists, please contact our support team.\n"
     exit 1
   fi


### PR DESCRIPTION
If valid, output is:

```
-----> Downloading Scalingo client...  DONE
-----> Verifying the checksum...  VALID
[...]
```

If invalid, output is:

```
-----> Downloading Scalingo client...  DONE
-----> Verifying the checksum...  INVALID
 !     Checksums don't match ('3fdec56b8647953744fe4c9094dd7b0a0952b1cb9416bc7e315cde00b8db557a' != '3fdec56b8647953744fe4c9094dd7b0a0952b1cb9416bc7e315cde00b8db557a')
 !     You may want to retry to install the Scalingo CLI. If the problem persists, please contact our support team.
```

I'm not sure we want to keep displaying the checksums in the error message, what do you think?

Fix #422

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md