### PR TITLE
fix(events): `link_scm` data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * feat(addons): add maintenance windows manipulation with the new `addon-config` command ([PR#955](https://github.com/Scalingo/cli/pull/955))
 * feat(install.sh): verify the archive checksum ([PR#988](https://github.com/Scalingo/cli/pull/988))
 * feat(region): more debug logs  ([PR#1007](https://github.com/Scalingo/cli/pull/1008))
+* fix(events): `link_scm` data types
 
 ### 1.29.1
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
-	github.com/Scalingo/go-scalingo/v6 v6.7.4
+	github.com/Scalingo/go-scalingo/v6 v6.7.5
 	github.com/Scalingo/go-utils/errors/v2 v2.3.0
 	github.com/Scalingo/go-utils/logger v1.2.0
 	github.com/Scalingo/go-utils/retry v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c h1:kMFnB0vCcX7IL/m9Y5LO+KQYv+t1CQOiFe6+SV2J7bE=
 github.com/ProtonMail/go-crypto v0.0.0-20230923063757-afb1ddc0824c/go.mod h1:EjAoLdwvbIOoOQr3ihjnSoLZRtE8azugULFRteWMNc0=
-github.com/Scalingo/go-scalingo/v6 v6.7.4 h1:bO2POIVsaORI78JMZV9DYa17YVD5ppNBmUn0ur8FaNQ=
-github.com/Scalingo/go-scalingo/v6 v6.7.4/go.mod h1:i7SU6/4FF1PsZ9NjvJ5yVQlHmrYSBkoIP6O2X7LkIWI=
+github.com/Scalingo/go-scalingo/v6 v6.7.5 h1:88G7v77Pd7q6CjODCzjnD9zBpcoZfmDY6nyUzihxWKE=
+github.com/Scalingo/go-scalingo/v6 v6.7.5/go.mod h1:rjp3U/gawXdy9vhGZKHySa2v0CMnJCGQjtobhZw8DPg=
 github.com/Scalingo/go-utils/errors/v2 v2.3.0 h1:9Ju4EmxXWoUsm0LOEWyEYUfT503l78YeQx0r6i1MdBI=
 github.com/Scalingo/go-utils/errors/v2 v2.3.0/go.mod h1:ovQmOjKaifysELQaMU21SAy8nqhZQ3xW/xrj0Ed9lWo=
 github.com/Scalingo/go-utils/logger v1.2.0 h1:E3jtaoRxpIsFcZu/jsvWew8ttUAwKUYQufdPqGYp7EU=

--- a/vendor/github.com/Scalingo/go-scalingo/v6/CHANGELOG.md
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## To Be Released
 
+## 6.7.5
+
+fix(events): `link_scm` data types
+
 ## 6.7.4
 
 * feat(database): add user management

--- a/vendor/github.com/Scalingo/go-scalingo/v6/README.md
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/README.md
@@ -1,6 +1,6 @@
 [ ![Codeship Status for Scalingo/go-scalingo](https://app.codeship.com/projects/cf518dc0-0034-0136-d6b3-5a0245e77f67/status?branch=master)](https://app.codeship.com/projects/279805)
 
-# Go client for Scalingo API v6.7.4
+# Go client for Scalingo API v6.7.5
 
 This repository is the Go client for the [Scalingo APIs](https://developers.scalingo.com/).
 
@@ -80,7 +80,7 @@ Bump new version number in:
 Commit, tag and create a new release:
 
 ```sh
-version="6.7.4"
+version="6.7.5"
 
 git switch --create release/${version}
 git add CHANGELOG.md README.md version.go

--- a/vendor/github.com/Scalingo/go-scalingo/v6/events_structs.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/events_structs.go
@@ -253,13 +253,13 @@ type EventLinkSCMTypeData struct {
 	LinkerUsername           string `json:"linker_username"`
 	Source                   string `json:"source"`
 	Branch                   string `json:"branch"`
-	AutoDeploy               string `json:"auto_deploy"`
-	AutoDeployReviewApps     string `json:"auto_deploy_review_apps"`
-	DeleteOnClose            string `json:"delete_on_close"`
-	DeleteStale              string `json:"delete_stale"`
-	HoursBeforeDeleteOnClose string `json:"hours_before_delete_on_close"`
-	HoursBeforeDeleteStale   string `json:"hours_before_delete_stale"`
-	CreationFromForksAllowed string `json:"creation_from_forks_allowed"`
+	AutoDeploy               bool   `json:"auto_deploy"`
+	AutoDeployReviewApps     bool   `json:"auto_deploy_review_apps"`
+	DeleteOnClose            bool   `json:"delete_on_close"`
+	DeleteStale              bool   `json:"delete_stale"`
+	HoursBeforeDeleteOnClose int    `json:"hours_before_delete_on_close"`
+	HoursBeforeDeleteStale   int    `json:"hours_before_delete_stale"`
+	CreationFromForksAllowed bool   `json:"creation_from_forks_allowed"`
 }
 
 type EventUpdateSCMType struct {

--- a/vendor/github.com/Scalingo/go-scalingo/v6/version.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "6.7.4"
+var Version = "6.7.5"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -33,7 +33,7 @@ github.com/ProtonMail/go-crypto/openpgp/internal/ecc
 github.com/ProtonMail/go-crypto/openpgp/internal/encoding
 github.com/ProtonMail/go-crypto/openpgp/packet
 github.com/ProtonMail/go-crypto/openpgp/s2k
-# github.com/Scalingo/go-scalingo/v6 v6.7.4
+# github.com/Scalingo/go-scalingo/v6 v6.7.5
 ## explicit; go 1.20
 github.com/Scalingo/go-scalingo/v6
 github.com/Scalingo/go-scalingo/v6/billing


### PR DESCRIPTION
```
❯ go run scalingo/main.go --app biniou timeline
* Wed Dec 20 2023 15:18:23 - Link Scm           - app has been linked to repository 'EtienneM/sample-go-gin' <etiennem (etienne@scalingo.com)>
```

Fix #1022

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md