### PR TITLE
feat(cmd): add database user password update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### To be Released
 
 * fix(autocomplete): do not show update message on autocomplete
+* feat(databases): add databases users update
 
 ### 1.30.1
 

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -250,6 +250,7 @@ var (
 		&databaseListUsers,
 		&databaseDeleteUser,
 		&databaseCreateUser,
+		&databaseUpdateUserPassword,
 
 		// Maintenance
 		&databaseMaintenanceList,

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -242,6 +242,43 @@ Only available on ` + fmt.Sprintf("%s", dbUsers.SupportedAddons),
 			return nil
 		},
 	}
+	databaseUpdateUserPassword = cli.Command{
+		Name:      "database-users-update-password",
+		Aliases:   []string{"database-update-user-password"},
+		Category:  "Addons",
+		ArgsUsage: "user",
+		Usage:     "Update a database user's password",
+		Flags: []cli.Flag{
+			&appFlag,
+			&addonFlag,
+		},
+		Description: CommandDescription{
+			Description: `Update password for unprotected database user.
+
+Only available on ` + fmt.Sprintf("%s", dbUsers.SupportedAddons),
+			Examples: []string{
+				"scalingo --app myapp --addon addon-uuid database-users-update-password my_user",
+			},
+		}.Render(),
+
+		Action: func(c *cli.Context) error {
+			if c.NArg() < 1 {
+				return cli.ShowCommandHelp(c, "database-users-update-password")
+			}
+
+			currentApp := detect.CurrentApp(c)
+			utils.CheckForConsent(c.Context, currentApp, utils.ConsentTypeDBs)
+			addonName := addonUUIDFromFlags(c, currentApp, true)
+
+			username := c.Args().First()
+
+			err := dbUsers.UpdateUser(c.Context, currentApp, addonName, username)
+			if err != nil {
+				errorQuit(c.Context, err)
+			}
+			return nil
+		},
+	}
 )
 
 func parseScheduleAtFlag(flag string) (int, *time.Location, error) {

--- a/db/users/create.go
+++ b/db/users/create.go
@@ -10,14 +10,14 @@ import (
 	"github.com/Scalingo/cli/config"
 	"github.com/Scalingo/cli/io"
 	"github.com/Scalingo/go-scalingo/v6"
-	scErrors "github.com/Scalingo/go-utils/errors/v2"
+	"github.com/Scalingo/go-utils/errors/v2"
 	"github.com/Scalingo/gopassword"
 )
 
 func CreateUser(ctx context.Context, app, addonUUID, username string, readonly bool) error {
 	isSupported, err := doesDatabaseHandleUserManagement(ctx, app, addonUUID)
 	if err != nil {
-		return scErrors.Wrap(ctx, err, "get user management information")
+		return errors.Wrap(ctx, err, "get user management information")
 	}
 
 	if !isSupported {
@@ -32,7 +32,7 @@ func CreateUser(ctx context.Context, app, addonUUID, username string, readonly b
 
 	password, confirmedPassword, err := askForPassword(ctx)
 	if err != nil {
-		return scErrors.Wrap(ctx, err, "ask for password")
+		return errors.Wrap(ctx, err, "ask for password")
 	}
 
 	passwordValidation, ok := isPasswordValid(password, confirmedPassword)
@@ -50,7 +50,7 @@ func CreateUser(ctx context.Context, app, addonUUID, username string, readonly b
 
 	c, err := config.ScalingoClient(ctx)
 	if err != nil {
-		return scErrors.Wrap(ctx, err, "get Scalingo client")
+		return errors.Wrap(ctx, err, "get Scalingo client")
 	}
 
 	user := scalingo.DatabaseCreateUserParam{
@@ -62,7 +62,7 @@ func CreateUser(ctx context.Context, app, addonUUID, username string, readonly b
 	}
 	databaseUsers, err := c.DatabaseCreateUser(ctx, app, addonUUID, user)
 	if err != nil {
-		return scErrors.Wrap(ctx, err, "create the given database user")
+		return errors.Wrap(ctx, err, "create the given database user")
 	}
 
 	if isPasswordGenerated {
@@ -79,13 +79,13 @@ func askForPassword(ctx context.Context) (string, string, error) {
 
 	password, err := term.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
-		return "", "", scErrors.Wrap(ctx, err, "read password")
+		return "", "", errors.Wrap(ctx, err, "read password")
 	}
 
 	fmt.Printf("\nPassword Confirmation: ")
 	confirmedPassword, err := term.ReadPassword(int(os.Stdin.Fd()))
 	if err != nil {
-		return "", "", scErrors.Wrap(ctx, err, "read password confirmation")
+		return "", "", errors.Wrap(ctx, err, "read password confirmation")
 	}
 	fmt.Println()
 

--- a/db/users/create.go
+++ b/db/users/create.go
@@ -3,9 +3,6 @@ package users
 import (
 	"context"
 	"fmt"
-	"os"
-
-	"golang.org/x/term"
 
 	"github.com/Scalingo/cli/config"
 	"github.com/Scalingo/cli/io"
@@ -30,14 +27,9 @@ func CreateUser(ctx context.Context, app, addonUUID, username string, readonly b
 		return nil
 	}
 
-	password, confirmedPassword, err := askForPassword(ctx)
+	password, confirmedPassword, err := askForPasswordWithRetry(ctx, 3)
 	if err != nil {
-		return errors.Wrap(ctx, err, "ask for password")
-	}
-
-	passwordValidation, ok := isPasswordValid(password, confirmedPassword)
-	if !ok && password != "" {
-		io.Error(passwordValidation)
+		io.Error(err)
 		return nil
 	}
 
@@ -72,39 +64,4 @@ func CreateUser(ctx context.Context, app, addonUUID, username string, readonly b
 
 	fmt.Printf("User \"%s\" created.\n", databaseUsers.Name)
 	return nil
-}
-
-func askForPassword(ctx context.Context) (string, string, error) {
-	fmt.Printf("Password (Will be generated if left empty): ")
-
-	password, err := term.ReadPassword(int(os.Stdin.Fd()))
-	if err != nil {
-		return "", "", errors.Wrap(ctx, err, "read password")
-	}
-
-	fmt.Printf("\nPassword Confirmation: ")
-	confirmedPassword, err := term.ReadPassword(int(os.Stdin.Fd()))
-	if err != nil {
-		return "", "", errors.Wrap(ctx, err, "read password confirmation")
-	}
-	fmt.Println()
-
-	return string(password), string(confirmedPassword), nil
-}
-
-func isPasswordValid(password, confirmedPassword string) (string, bool) {
-	if password != confirmedPassword {
-		return "Password confirmation doesn't match", false
-	}
-	if len(password) < 8 || len(password) > 64 {
-		return "Password must contain between 8 and 64 characters", false
-	}
-	return "", true
-}
-
-func isUsernameValid(username string) (string, bool) {
-	if len(username) < 6 || len(username) > 32 {
-		return "name must contain between 6 and 32 characters", false
-	}
-	return "", true
 }

--- a/db/users/delete.go
+++ b/db/users/delete.go
@@ -7,13 +7,13 @@ import (
 	"github.com/Scalingo/cli/config"
 	"github.com/Scalingo/cli/io"
 	"github.com/Scalingo/go-scalingo/v6"
-	scErrors "github.com/Scalingo/go-utils/errors/v2"
+	"github.com/Scalingo/go-utils/errors/v2"
 )
 
 func DeleteUser(ctx context.Context, app, addonUUID, username string) error {
 	isSupported, err := doesDatabaseHandleUserManagement(ctx, app, addonUUID)
 	if err != nil {
-		return scErrors.Wrap(ctx, err, "get user management information")
+		return errors.Wrap(ctx, err, "get user management information")
 	}
 
 	if !isSupported {
@@ -23,12 +23,12 @@ func DeleteUser(ctx context.Context, app, addonUUID, username string) error {
 
 	c, err := config.ScalingoClient(ctx)
 	if err != nil {
-		return scErrors.Wrap(ctx, err, "get Scalingo client")
+		return errors.Wrap(ctx, err, "get Scalingo client")
 	}
 
 	databaseUsers, err := c.DatabaseListUsers(ctx, app, addonUUID)
 	if err != nil {
-		return scErrors.Wrap(ctx, err, "list the database's users")
+		return errors.Wrap(ctx, err, "list the database's users")
 	}
 
 	var givenUser *scalingo.DatabaseUser
@@ -50,7 +50,7 @@ func DeleteUser(ctx context.Context, app, addonUUID, username string) error {
 
 	err = c.DatabaseDeleteUser(ctx, app, addonUUID, username)
 	if err != nil {
-		return scErrors.Wrapf(ctx, err, "delete given user from database %v", username)
+		return errors.Wrapf(ctx, err, "delete given user from database %v", username)
 	}
 	return nil
 }

--- a/db/users/list.go
+++ b/db/users/list.go
@@ -9,13 +9,13 @@ import (
 
 	"github.com/Scalingo/cli/config"
 	"github.com/Scalingo/cli/io"
-	scErrors "github.com/Scalingo/go-utils/errors/v2"
+	"github.com/Scalingo/go-utils/errors/v2"
 )
 
 func List(ctx context.Context, app, addonUUID string) error {
 	isSupported, err := doesDatabaseHandleUserManagement(ctx, app, addonUUID)
 	if err != nil {
-		return scErrors.Wrap(ctx, err, "get user management information")
+		return errors.Wrap(ctx, err, "get user management information")
 	}
 
 	if !isSupported {
@@ -25,12 +25,12 @@ func List(ctx context.Context, app, addonUUID string) error {
 
 	c, err := config.ScalingoClient(ctx)
 	if err != nil {
-		return scErrors.Wrap(ctx, err, "get Scalingo client")
+		return errors.Wrap(ctx, err, "get Scalingo client")
 	}
 
 	databaseUsers, err := c.DatabaseListUsers(ctx, app, addonUUID)
 	if err != nil {
-		return scErrors.Wrap(ctx, err, "list the database's users")
+		return errors.Wrap(ctx, err, "list the database's users")
 	}
 
 	header := []string{"Username", "Read-Only", "Protected"}

--- a/db/users/update.go
+++ b/db/users/update.go
@@ -1,0 +1,70 @@
+package users
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Scalingo/cli/config"
+	"github.com/Scalingo/cli/io"
+	"github.com/Scalingo/go-scalingo/v6"
+	"github.com/Scalingo/go-utils/errors/v2"
+	"github.com/Scalingo/gopassword"
+)
+
+func UpdateUser(ctx context.Context, app, addonUUID, username string) error {
+	isSupported, err := doesDatabaseHandleUserManagement(ctx, app, addonUUID)
+	if err != nil {
+		return errors.Wrap(ctx, err, "get user management information")
+	}
+
+	if !isSupported {
+		io.Error(ErrDatabaseNotSupportUserManagement)
+		return nil
+	}
+
+	if usernameValidation, ok := isUsernameValid(username); !ok {
+		io.Error(usernameValidation)
+		return nil
+	}
+
+	password, confirmedPassword, err := askForPassword(ctx)
+	if err != nil {
+		return errors.Wrap(ctx, err, "ask for password")
+	}
+
+	passwordValidation, ok := isPasswordValid(password, confirmedPassword)
+	if !ok && password != "" {
+		io.Error(passwordValidation)
+		return nil
+	}
+
+	isPasswordGenerated := false
+	if password == "" {
+		isPasswordGenerated = true
+		password = gopassword.Generate(64)
+		confirmedPassword = password
+	}
+
+	c, err := config.ScalingoClient(ctx)
+	if err != nil {
+		return errors.Wrap(ctx, err, "get Scalingo client")
+	}
+
+	user := scalingo.DatabaseUpdateUserParam{
+		DatabaseID:           addonUUID,
+		Password:             password,
+		PasswordConfirmation: confirmedPassword,
+	}
+	databaseUsers, err := c.DatabaseUpdateUser(ctx, app, addonUUID, username, user)
+	if err != nil {
+		return errors.Wrap(ctx, err, "update password of the given database user")
+	}
+
+	if isPasswordGenerated {
+		fmt.Printf("User \"%s\" updated with password \"%s\".\n", databaseUsers.Name, password)
+		return nil
+	}
+
+	fmt.Printf("User \"%s\" password updated.\n", databaseUsers.Name)
+	return nil
+}

--- a/db/users/utils.go
+++ b/db/users/utils.go
@@ -2,27 +2,27 @@ package users
 
 import (
 	"context"
-	"errors"
+	stdErrors "errors"
 	"strings"
 
 	"github.com/Scalingo/cli/config"
-	scErrors "github.com/Scalingo/go-utils/errors/v2"
+	"github.com/Scalingo/go-utils/errors/v2"
 )
 
 var (
 	SupportedAddons                     = []string{"PostgreSQL", "InfluxDB", "MongoDB", "MySQL"}
-	ErrDatabaseNotSupportUserManagement = errors.New("Error: DBMS does not support user management")
+	ErrDatabaseNotSupportUserManagement = stdErrors.New("Error: DBMS does not support user management")
 )
 
 func doesDatabaseHandleUserManagement(ctx context.Context, app, addonUUID string) (bool, error) {
 	addonsClient, err := config.ScalingoClient(ctx)
 	if err != nil {
-		return false, scErrors.Wrap(ctx, err, "get Scalingo client")
+		return false, errors.Wrap(ctx, err, "get Scalingo client")
 	}
 
 	addon, err := addonsClient.AddonShow(ctx, app, addonUUID)
 	if err != nil {
-		return false, scErrors.Wrap(ctx, err, "get the addon to check user management support")
+		return false, errors.Wrap(ctx, err, "get the addon to check user management support")
 	}
 
 	for _, supportedAddon := range SupportedAddons {

--- a/db/users/utils.go
+++ b/db/users/utils.go
@@ -3,9 +3,14 @@ package users
 import (
 	"context"
 	stdErrors "errors"
+	"fmt"
+	"os"
 	"strings"
 
+	"golang.org/x/term"
+
 	"github.com/Scalingo/cli/config"
+	"github.com/Scalingo/cli/io"
 	"github.com/Scalingo/go-utils/errors/v2"
 )
 
@@ -32,4 +37,65 @@ func doesDatabaseHandleUserManagement(ctx context.Context, app, addonUUID string
 	}
 
 	return false, nil
+}
+
+func askForPasswordWithRetry(ctx context.Context, remainingRetries int) (string, string, error) {
+	if remainingRetries <= 0 {
+		return "", "", errors.New(ctx, "No retries left")
+	}
+
+	password, confirmedPassword, err := askForPassword(ctx)
+	if err != nil {
+		return "", "", errors.Wrap(ctx, err, "ask for password")
+	}
+
+	passwordValidation, ok := isPasswordValid(password, confirmedPassword)
+	if !ok {
+		if remainingRetries == 1 {
+			return "", "", errors.Newf(ctx, "%s. Too many retries", passwordValidation)
+		}
+		io.Error(fmt.Sprintf("%s. Remaining retries: %v", passwordValidation, remainingRetries-1))
+		return askForPasswordWithRetry(ctx, remainingRetries-1)
+	}
+
+	return password, confirmedPassword, nil
+}
+
+func askForPassword(ctx context.Context) (string, string, error) {
+	fmt.Printf("Password (Will be generated if left empty): ")
+
+	password, err := term.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		return "", "", errors.Wrap(ctx, err, "read password")
+	}
+
+	fmt.Printf("\nPassword Confirmation: ")
+	confirmedPassword, err := term.ReadPassword(int(os.Stdin.Fd()))
+	if err != nil {
+		return "", "", errors.Wrap(ctx, err, "read password confirmation")
+	}
+	fmt.Println()
+
+	return string(password), string(confirmedPassword), nil
+}
+
+func isPasswordValid(password, confirmedPassword string) (string, bool) {
+	if password == "" && confirmedPassword == "" {
+		return "", true
+	}
+
+	if password != confirmedPassword {
+		return "Password confirmation doesn't match", false
+	}
+	if len(password) < 8 || len(password) > 64 {
+		return "Password must contain between 8 and 64 characters", false
+	}
+	return "", true
+}
+
+func isUsernameValid(username string) (string, bool) {
+	if len(username) < 6 || len(username) > 32 {
+		return "name must contain between 6 and 32 characters", false
+	}
+	return "", true
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
-	github.com/Scalingo/go-scalingo/v6 v6.7.6
+	github.com/Scalingo/go-scalingo/v6 v6.7.7
 	github.com/Scalingo/go-utils/errors/v2 v2.3.0
 	github.com/Scalingo/go-utils/logger v1.2.0
 	github.com/Scalingo/go-utils/retry v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.0 h1:nHGfwXmFvJrSR9xu8qL7BkO4DqTHXE9N5vPhgY2I+j0=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.0/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/Scalingo/go-scalingo/v6 v6.7.6 h1:VXpF0bULRe4r+dvoAPlnxs8OK4B2awPyIdywppBkaw8=
-github.com/Scalingo/go-scalingo/v6 v6.7.6/go.mod h1:GCQ0KuiYKWr1EXqYXolZ+j7R5+DVjKr2K2t7CrayzW0=
+github.com/Scalingo/go-scalingo/v6 v6.7.7 h1:pDjEtcl7z3oJ3t7s5TieWBbr5wlzF/J/7mIHzBCrRBY=
+github.com/Scalingo/go-scalingo/v6 v6.7.7/go.mod h1:GCQ0KuiYKWr1EXqYXolZ+j7R5+DVjKr2K2t7CrayzW0=
 github.com/Scalingo/go-utils/errors/v2 v2.3.0 h1:9Ju4EmxXWoUsm0LOEWyEYUfT503l78YeQx0r6i1MdBI=
 github.com/Scalingo/go-utils/errors/v2 v2.3.0/go.mod h1:ovQmOjKaifysELQaMU21SAy8nqhZQ3xW/xrj0Ed9lWo=
 github.com/Scalingo/go-utils/logger v1.2.0 h1:E3jtaoRxpIsFcZu/jsvWew8ttUAwKUYQufdPqGYp7EU=

--- a/vendor/github.com/Scalingo/go-scalingo/v6/CHANGELOG.md
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/CHANGELOG.md
@@ -2,13 +2,17 @@
 
 ## To Be Released
 
+## 6.7.7
+
+* feat(databases): add databases user update
+
 ## 6.7.6
 
-fix(errors): `IsOTPRequired` detects 'OTP Required' API errors
+* fix(errors): `IsOTPRequired` detects 'OTP Required' API errors
 
 ## 6.7.5
 
-fix(events): `link_scm` data types
+* fix(events): `link_scm` data types
 
 ## 6.7.4
 

--- a/vendor/github.com/Scalingo/go-scalingo/v6/README.md
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/README.md
@@ -1,6 +1,6 @@
 [ ![Codeship Status for Scalingo/go-scalingo](https://app.codeship.com/projects/cf518dc0-0034-0136-d6b3-5a0245e77f67/status?branch=master)](https://app.codeship.com/projects/279805)
 
-# Go client for Scalingo API v6.7.6
+# Go client for Scalingo API v6.7.7
 
 This repository is the Go client for the [Scalingo APIs](https://developers.scalingo.com/).
 
@@ -80,7 +80,7 @@ Bump new version number in:
 Commit, tag and create a new release:
 
 ```sh
-version="6.7.6"
+version="6.7.7"
 
 git switch --create release/${version}
 git add CHANGELOG.md README.md version.go

--- a/vendor/github.com/Scalingo/go-scalingo/v6/databases.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/databases.go
@@ -277,6 +277,29 @@ func (c *Client) DatabaseCreateUser(ctx context.Context, app, addonID string, us
 	return res.DatabaseUser, nil
 }
 
+type DatabaseUpdateUserParam struct {
+	DatabaseID           string `json:"database_id"`
+	Password             string `json:"password,omitempty"`
+	PasswordConfirmation string `json:"password_confirmation,omitempty"`
+}
+
+type databaseUpdateUserPayload struct {
+	DatabaseUser DatabaseUpdateUserParam `json:"database_user"`
+}
+
+// DatabaseUpdateUser updates a user to the given database addon
+func (c *Client) DatabaseUpdateUser(ctx context.Context, app, addonID, username string, databaseUserParams DatabaseUpdateUserParam) (DatabaseUser, error) {
+	res := DatabaseUserResponse{}
+	payload := databaseUpdateUserPayload{
+		DatabaseUser: databaseUserParams,
+	}
+	err := c.DBAPI(app, addonID).SubresourceUpdate(ctx, "databases", addonID, "users", username, payload, &res)
+	if err != nil {
+		return res.DatabaseUser, errors.Wrapf(ctx, err, "update a user on database %s", addonID)
+	}
+	return res.DatabaseUser, nil
+}
+
 // DatabaseUsersResponse is the response body of database list users
 type DatabaseUsersResponse struct {
 	DatabaseUsers []DatabaseUser `json:"database-users"`

--- a/vendor/github.com/Scalingo/go-scalingo/v6/http/client.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/http/client.go
@@ -24,7 +24,7 @@ type Client interface {
 	SubresourceList(ctx context.Context, resource, resourceID, subresource string, payload, data interface{}) error
 	SubresourceAdd(ctx context.Context, resource, resourceID, subresource string, payload, data interface{}) error
 	SubresourceGet(ctx context.Context, resource, resourceID, subresource, id string, payload, data interface{}) error
-	SubresourceUpdate(rctx context.Context, esource, resourceID, subresource, id string, payload, data interface{}) error
+	SubresourceUpdate(ctx context.Context, resource, resourceID, subresource, id string, payload, data interface{}) error
 	SubresourceDelete(ctx context.Context, resource, resourceID, subresource, id string) error
 	DoRequest(ctx context.Context, req *APIRequest, data interface{}) error
 	Do(context.Context, *APIRequest) (*http.Response, error)

--- a/vendor/github.com/Scalingo/go-scalingo/v6/version.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v6/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "6.7.6"
+var Version = "6.7.7"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -37,7 +37,7 @@ github.com/ProtonMail/go-crypto/openpgp/packet
 github.com/ProtonMail/go-crypto/openpgp/s2k
 github.com/ProtonMail/go-crypto/openpgp/x25519
 github.com/ProtonMail/go-crypto/openpgp/x448
-# github.com/Scalingo/go-scalingo/v6 v6.7.6
+# github.com/Scalingo/go-scalingo/v6 v6.7.7
 ## explicit; go 1.20
 github.com/Scalingo/go-scalingo/v6
 github.com/Scalingo/go-scalingo/v6/billing


### PR DESCRIPTION
- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md
- [x] Need https://github.com/Scalingo/go-scalingo/pull/373 to be released

## Examples

Max retry reached

```bash
➜ scalingo --app my-app --addon mysql database-users-update-password my_user
Password (Will be generated if left empty): 
Password Confirmation: 
 !     Password confirmation doesn't match. Remaining retries: 2
Password (Will be generated if left empty): 
Password Confirmation: 
 !     Password confirmation doesn't match. Remaining retries: 1
Password (Will be generated if left empty): 
Password Confirmation: 
 !     Password confirmation doesn't match. Too many retries
```

User does not exists

```bash
➜ scalingo --app my-app --addon mysql database-users-update-password user_does_not_exists
 !     An error occurred:
       User "user_does_not_exists" does not exist
```

It works after a retry

```bash
➜ scalingo --app my-app --addon mysql database-users-update-password my_user
Password (Will be generated if left empty): 
Password Confirmation: 
 !     Password confirmation doesn't match. Remaining retries: 2
Password (Will be generated if left empty): 
Password Confirmation: 
User "my_user" password updated.
```

It works generates a password

```bash
➜ scalingo --app my-app --addon mysql database-users-update-password my_user
Password (Will be generated if left empty): 
Password Confirmation: 
User "my_user" updated with password "this_is_a_generated_password".
```

Fixes #1034 