### PR TITLE
build(publish): fech depth to 2 for linter on master branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # We needed to define the fetch-depth to 0 so that we can get the commit ID of the master branch
+          # We need to define the fetch-depth to 0 so that we can get the commit ID of the master branch
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
@@ -40,6 +40,9 @@ jobs:
     if: github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
+        with:
+          # We need to define the fetch-depth to 2 so that we can get new offenses since HEAD~1
+          fetch-depth: 2
       - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"


### PR DESCRIPTION
The CI currently fails on master. For instance: https://github.com/Scalingo/cli/actions/runs/7900369881/job/21561746176

This is because of the error:

```
level=warning msg="[runner] Can't process result by diff processor: can't prepare diff by revgrep: could not read git repo: error executing git diff \"HEAD~1\" \"\": exit status 128"
```

This PR is a fix for the code introduced in #758


n/a:
- [ ] Add a changelog entry in the section "To Be Released" of CHANGELOG.md