### PR TITLE
[STORY-642] new api endpoint to handle password reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### To be Released
 
-* feat(database/users): use API DatabaseUserPasswordReset method for resetting password
+* feat(database/users): use API DatabaseUserResetPassword method for resetting password
 
 ### 1.32.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### To be Released
 
+* feat(database/users): use API DatabaseUserPasswordReset method for resetting password
+
 ### 1.32.0
 
 * feat(domains): `domains-add` now supports `--no-letsencrypt` flag to completely disable Let's Encrypt certificat generation ([PR#1058](https://github.com/Scalingo/cli/pull/1058))

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -272,7 +272,7 @@ Only available on ` + fmt.Sprintf("%s", dbUsers.SupportedAddons),
 
 			username := c.Args().First()
 
-			err := dbUsers.UpdateUser(c.Context, currentApp, addonName, username)
+			err := dbUsers.UpdateUserPassword(c.Context, currentApp, addonName, username)
 			if err != nil {
 				errorQuit(c.Context, err)
 			}

--- a/db/users/update_password.go
+++ b/db/users/update_password.go
@@ -74,16 +74,16 @@ func UpdateUserPassword(ctx context.Context, app, addonUUID, username string) er
 		if err != nil {
 			return errors.Wrap(ctx, err, "update password of the given database user")
 		}
-	} else {
-		databaseUser, err = c.DatabaseUserResetPassword(ctx, app, addonUUID, username)
-		if err != nil {
-			return errors.Wrap(ctx, err, "reset the password of the given database user")
-		}
 
-		fmt.Printf("User \"%s\" updated with password \"%s\".\n", databaseUser.Name, databaseUser.Password)
+		fmt.Printf("User \"%s\" password updated.\n", databaseUser.Name)
 		return nil
 	}
 
-	fmt.Printf("User \"%s\" password updated.\n", databaseUser.Name)
+	databaseUser, err = c.DatabaseUserResetPassword(ctx, app, addonUUID, username)
+	if err != nil {
+		return errors.Wrap(ctx, err, "reset the password of the given database user")
+	}
+
+	fmt.Printf("User \"%s\" updated with password \"%s\".\n", databaseUser.Name, databaseUser.Password)
 	return nil
 }

--- a/db/users/update_password.go
+++ b/db/users/update_password.go
@@ -8,10 +8,9 @@ import (
 	"github.com/Scalingo/cli/io"
 	"github.com/Scalingo/go-scalingo/v7"
 	"github.com/Scalingo/go-utils/errors/v2"
-	"github.com/Scalingo/gopassword"
 )
 
-func UpdateUser(ctx context.Context, app, addonUUID, username string) error {
+func UpdateUserPassword(ctx context.Context, app, addonUUID, username string) error {
 	isSupported, err := doesDatabaseHandleUserManagement(ctx, app, addonUUID)
 	if err != nil {
 		return errors.Wrap(ctx, err, "get user management information")
@@ -60,25 +59,31 @@ func UpdateUser(ctx context.Context, app, addonUUID, username string) error {
 	isPasswordGenerated := false
 	if password == "" {
 		isPasswordGenerated = true
-		password = gopassword.Generate(64)
-		confirmedPassword = password
 	}
 
-	userUpdateParam := scalingo.DatabaseUpdateUserParam{
-		DatabaseID:           addonUUID,
-		Password:             password,
-		PasswordConfirmation: confirmedPassword,
-	}
-	databaseUsers, err := c.DatabaseUpdateUser(ctx, app, addonUUID, username, userUpdateParam)
-	if err != nil {
-		return errors.Wrap(ctx, err, "update password of the given database user")
-	}
+	var databaseUser scalingo.DatabaseUser
 
-	if isPasswordGenerated {
-		fmt.Printf("User \"%s\" updated with password \"%s\".\n", databaseUsers.Name, password)
+	// We have two different API calls here to avoid breaking backwards compatibility of the CLI
+	if !isPasswordGenerated {
+		userUpdateParam := scalingo.DatabaseUpdateUserParam{
+			DatabaseID:           addonUUID,
+			Password:             password,
+			PasswordConfirmation: confirmedPassword,
+		}
+		databaseUser, err = c.DatabaseUpdateUser(ctx, app, addonUUID, username, userUpdateParam)
+		if err != nil {
+			return errors.Wrap(ctx, err, "update password of the given database user")
+		}
+	} else {
+		databaseUser, err = c.DatabaseUserPasswordReset(ctx, app, addonUUID, username)
+		if err != nil {
+			return errors.Wrap(ctx, err, "reset the password of the given database user")
+		}
+
+		fmt.Printf("User \"%s\" updated with password \"%s\".\n", databaseUser.Name, databaseUser.Password)
 		return nil
 	}
 
-	fmt.Printf("User \"%s\" password updated.\n", databaseUsers.Name)
+	fmt.Printf("User \"%s\" password updated.\n", databaseUser.Name)
 	return nil
 }

--- a/db/users/update_password.go
+++ b/db/users/update_password.go
@@ -75,7 +75,7 @@ func UpdateUserPassword(ctx context.Context, app, addonUUID, username string) er
 			return errors.Wrap(ctx, err, "update password of the given database user")
 		}
 	} else {
-		databaseUser, err = c.DatabaseUserPasswordReset(ctx, app, addonUUID, username)
+		databaseUser, err = c.DatabaseUserResetPassword(ctx, app, addonUUID, username)
 		if err != nil {
 			return errors.Wrap(ctx, err, "reset the password of the given database user")
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
-	github.com/Scalingo/go-scalingo/v7 v7.0.0
+	github.com/Scalingo/go-scalingo/v7 v7.0.1
 	github.com/Scalingo/go-utils/errors/v2 v2.4.0
 	github.com/Scalingo/go-utils/logger v1.2.0
 	github.com/Scalingo/go-utils/retry v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.3-proton h1:0RXAi0EJFs81j+MMsqvHNuAUGWzeVfCO9LnHAfoQ8NA=
 github.com/ProtonMail/go-crypto v1.1.0-alpha.3-proton/go.mod h1:rA3QumHc/FZ8pAHreoekgiAbzpNsfQAosU5td4SnOrE=
-github.com/Scalingo/go-scalingo/v7 v7.0.0 h1:y89FfQgjl8Foxm4+hXfCyGrpmtMnsB8G6kKuijXAUKI=
-github.com/Scalingo/go-scalingo/v7 v7.0.0/go.mod h1:UlRkN2cRyagSqAanCZWBgZDWsAQ/dk7xBdN51Fv6evM=
+github.com/Scalingo/go-scalingo/v7 v7.0.1 h1:Bpyy30AanC43qze6MzR9psf8v3V/MA+nExPVyOxAzoY=
+github.com/Scalingo/go-scalingo/v7 v7.0.1/go.mod h1:nraQDEEaoQwxKMmGux+eTXVeZNXWExS/kK7VkOvYGGw=
 github.com/Scalingo/go-utils/errors/v2 v2.4.0 h1:vKG0Js3kzWG7+03LEvH7j8fw+picEcRhbjMm3i9Xbb8=
 github.com/Scalingo/go-utils/errors/v2 v2.4.0/go.mod h1:WU6Kzi19AlZyUfoxFkdvEeYkIa0W0f172hKPqkOeIpU=
 github.com/Scalingo/go-utils/logger v1.2.0 h1:E3jtaoRxpIsFcZu/jsvWew8ttUAwKUYQufdPqGYp7EU=

--- a/vendor/github.com/Scalingo/go-scalingo/v7/CHANGELOG.md
+++ b/vendor/github.com/Scalingo/go-scalingo/v7/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## To Be Released
 
+## 7.0.1
+
+* feat(apps):  add the `private_network_ids` field to the model
+* feat(database/users): add the `DatabaseUserResetPassword` method
+
 ## 7.0.0
 
 * feat(domains): Add `letsencrypt_enabled` parameter

--- a/vendor/github.com/Scalingo/go-scalingo/v7/README.md
+++ b/vendor/github.com/Scalingo/go-scalingo/v7/README.md
@@ -1,6 +1,6 @@
 [ ![Codeship Status for Scalingo/go-scalingo](https://app.codeship.com/projects/cf518dc0-0034-0136-d6b3-5a0245e77f67/status?branch=master)](https://app.codeship.com/projects/279805)
 
-# Go client for Scalingo API v7.0.0
+# Go client for Scalingo API v7.0.1
 
 This repository is the Go client for the [Scalingo APIs](https://developers.scalingo.com/).
 
@@ -80,7 +80,7 @@ Bump new version number in:
 Commit, tag and create a new release:
 
 ```sh
-version="7.0.0"
+version="7.0.1"
 
 git switch --create release/${version}
 git add CHANGELOG.md README.md version.go

--- a/vendor/github.com/Scalingo/go-scalingo/v7/apps.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v7/apps.go
@@ -94,27 +94,28 @@ type AppLinks struct {
 }
 
 type App struct {
-	ID                string                 `json:"id"`
-	Name              string                 `json:"name"`
-	Region            string                 `json:"region"`
-	Owner             Owner                  `json:"owner"`
-	GitURL            string                 `json:"git_url"`
-	URL               string                 `json:"url"`
-	BaseURL           string                 `json:"base_url"`
-	Status            AppStatus              `json:"status"`
-	LastDeployedAt    *time.Time             `json:"last_deployed_at"`
-	LastDeployedBy    string                 `json:"last_deployed_by"`
-	CreatedAt         *time.Time             `json:"created_at"`
-	UpdatedAt         *time.Time             `json:"updated_at"`
-	Links             *AppLinks              `json:"links"`
-	StackID           string                 `json:"stack_id"`
-	StickySession     bool                   `json:"sticky_session"`
-	ForceHTTPS        bool                   `json:"force_https"`
-	RouterLogs        bool                   `json:"router_logs"`
-	DataAccessConsent *DataAccessConsent     `json:"data_access_consent,omitempty"`
-	Flags             map[string]bool        `json:"flags"`
-	Limits            map[string]interface{} `json:"limits"`
-	HDSResource       bool                   `json:"hds_resource"`
+	ID                 string                 `json:"id"`
+	Name               string                 `json:"name"`
+	Region             string                 `json:"region"`
+	Owner              Owner                  `json:"owner"`
+	GitURL             string                 `json:"git_url"`
+	URL                string                 `json:"url"`
+	BaseURL            string                 `json:"base_url"`
+	Status             AppStatus              `json:"status"`
+	LastDeployedAt     *time.Time             `json:"last_deployed_at"`
+	LastDeployedBy     string                 `json:"last_deployed_by"`
+	CreatedAt          *time.Time             `json:"created_at"`
+	UpdatedAt          *time.Time             `json:"updated_at"`
+	Links              *AppLinks              `json:"links"`
+	StackID            string                 `json:"stack_id"`
+	StickySession      bool                   `json:"sticky_session"`
+	ForceHTTPS         bool                   `json:"force_https"`
+	RouterLogs         bool                   `json:"router_logs"`
+	DataAccessConsent  *DataAccessConsent     `json:"data_access_consent,omitempty"`
+	Flags              map[string]bool        `json:"flags"`
+	Limits             map[string]interface{} `json:"limits"`
+	HDSResource        bool                   `json:"hds_resource"`
+	PrivateNetworksIDs []string               `json:"private_networks_ids"`
 }
 
 func (app App) String() string {

--- a/vendor/github.com/Scalingo/go-scalingo/v7/databases.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v7/databases.go
@@ -319,3 +319,19 @@ func (c *Client) DatabaseListUsers(ctx context.Context, app, addonID string) ([]
 func (c *Client) DatabaseDeleteUser(ctx context.Context, app, addonID, userName string) error {
 	return c.DBAPI(app, addonID).SubresourceDelete(ctx, "databases", addonID, "users", userName)
 }
+
+// DatabaseUserResetPassword resets the password for a user for given database addon
+func (c *Client) DatabaseUserResetPassword(ctx context.Context, app, addonID, username string) (DatabaseUser, error) {
+	res := DatabaseUserResponse{}
+	req := &httpclient.APIRequest{
+		Method:   "POST",
+		Endpoint: "/databases/" + addonID + "/users/" + username + "/reset_password",
+		Expected: httpclient.Statuses{http.StatusOK},
+	}
+	err := c.DBAPI(app, addonID).DoRequest(ctx, req, &res)
+	if err != nil {
+		return DatabaseUser{}, err
+	}
+
+	return res.DatabaseUser, nil
+}

--- a/vendor/github.com/Scalingo/go-scalingo/v7/version.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v7/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "7.0.0"
+var Version = "7.0.1"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -40,7 +40,7 @@ github.com/ProtonMail/go-crypto/openpgp/s2k
 github.com/ProtonMail/go-crypto/openpgp/symmetric
 github.com/ProtonMail/go-crypto/openpgp/x25519
 github.com/ProtonMail/go-crypto/openpgp/x448
-# github.com/Scalingo/go-scalingo/v7 v7.0.0
+# github.com/Scalingo/go-scalingo/v7 v7.0.1
 ## explicit; go 1.20
 github.com/Scalingo/go-scalingo/v7
 github.com/Scalingo/go-scalingo/v7/billing


### PR DESCRIPTION
- [ ] Add a changelog entry in the section "To Be Released" of CHANGELOG.md

Database user password update uses new API endpoint for generating password.

This is dependent on the merging / release of the equivalent branch in go-scalingo library.

[Story 642](https://www.notion.so/scalingooriginal/New-API-endpoint-to-handle-password-reset-662bd5bb9ec045308e5348f499055e65)