### PR TITLE
build(asgard): initialize

### DIFF
--- a/.sclng/metadata.toml
+++ b/.sclng/metadata.toml
@@ -1,0 +1,7 @@
+dependencies = []
+description = "'scalingo' CLI provided to users"
+flags = ["cli"]
+languages = ["go"]
+owner = "etienne@scalingo.com"
+team = "IST"
+version = "1.1.1"


### PR DESCRIPTION
I noticed that we didn't initialized this repository with Asgard

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md
=> it does not seem relevant to add a changelog entry for such change