### PR TITLE
[STORY--2042] Add OpenSearch support 

### DIFF
--- a/cmd/log_drains.go
+++ b/cmd/log_drains.go
@@ -58,7 +58,6 @@ Use the parameter "--with-addons" to list log drains of all addons connected to 
 			autocomplete.CmdFlagsAutoComplete(c, "log-drains")
 		},
 	}
-
 	logDrainsAddCommand = cli.Command{
 		Name:     "log-drains-add",
 		Category: "Log drains",
@@ -68,7 +67,7 @@ Use the parameter "--with-addons" to list log drains of all addons connected to 
 			&cli.BoolFlag{Name: "with-addons", Usage: "also add the log drains to all addons"},
 			&cli.BoolFlag{Name: "with-databases", Usage: "also add the log drains to all databases"},
 			&cli.StringFlag{Name: "type", Usage: "Communication protocol", Required: true},
-			&cli.StringFlag{Name: "url", Usage: "URL of self hosted ELK"},
+			&cli.StringFlag{Name: "url", Usage: "URL of self hosted ELK or OpenSearch"},
 			&cli.StringFlag{Name: "host", Usage: "Host of logs management service"},
 			&cli.StringFlag{Name: "port", Usage: "Port of logs management service"},
 			&cli.StringFlag{Name: "token", Usage: "Used by certain vendor for authentication"},
@@ -96,6 +95,7 @@ Warning: At the moment, only databases addons are able to forward logs to a drai
 				"scalingo --app my-app log-drains-add --type syslog --host custom.logstash.com --port 12345",
 				"scalingo --app my-app log-drains-add --type syslog --token 123456789abcdef --host custom.logstash.com --port 12345",
 				"scalingo --app my-app log-drains-add --type elk --url https://my-user:123456789abcdef@logstash-app-name.osc-fr1.scalingo.io",
+				"scalingo --app my-app log-drains-add --type opensearch --url https://my-user:123456789abcdef@my-app-name.opensearch.osc-fr1.scalingo-dbs.com:30123/yourindex/_doc?pipeline=your_pipeline",
 				"scalingo --app my-app --addon ad-3c2f8c81-99bd-4667-9791-466799bd4667 log-drains-add --type datadog --token 123456789abcdef --drain-region eu-west-2",
 				"scalingo --app my-app --with-addons log-drains-add --type datadog --token 123456789abcdef --drain-region eu-west-2",
 			},

--- a/logdrains/remove.go
+++ b/logdrains/remove.go
@@ -2,11 +2,11 @@ package logdrains
 
 import (
 	"context"
-
-	"gopkg.in/errgo.v1"
+	"strings"
 
 	"github.com/Scalingo/cli/config"
 	"github.com/Scalingo/cli/io"
+	"github.com/Scalingo/go-utils/errors/v2"
 )
 
 type RemoveAddonOpts struct {
@@ -18,14 +18,14 @@ type RemoveAddonOpts struct {
 func Remove(ctx context.Context, app string, opts RemoveAddonOpts) error {
 	c, err := config.ScalingoClient(ctx)
 	if err != nil {
-		return errgo.Notef(err, "fail to get Scalingo client to remove a log drain from the application")
+		return errors.Wrap(ctx, err, "get Scalingo client")
 	}
 
 	if opts.AddonID != "" {
 		// addon only
 		err := c.LogDrainAddonRemove(ctx, app, opts.AddonID, opts.URL)
 		if err != nil {
-			return errgo.Notef(err, "fail to remove the log drain from the addon %s", opts.AddonID)
+			return errors.Wrap(ctx, err, "remove log drain from addon "+opts.AddonID)
 		}
 		io.Status("The log drain", opts.URL, "has been deleted from the addon", opts.AddonID)
 		return nil
@@ -33,21 +33,26 @@ func Remove(ctx context.Context, app string, opts RemoveAddonOpts) error {
 
 	err = c.LogDrainRemove(ctx, app, opts.URL)
 	if err != nil {
-		io.Status("fail to remove the log drain from the application:", app, "\n\t", err)
-	} else {
-		io.Status("Log drain", opts.URL, "has been deleted from the application", app)
+		return errors.Wrap(ctx, err, "remove log drain from application "+app)
 	}
+	io.Status("Log drain", opts.URL, "has been deleted from the application", app)
 
 	if !opts.OnlyApp {
 		addons, err := c.AddonsList(ctx, app)
 		if err != nil {
-			return errgo.Notef(err, "fail to list addons to remove log drain")
+			return errors.Wrap(ctx, err, "list addons to remove log drain")
 		}
 
 		for _, addon := range addons {
 			err := c.LogDrainAddonRemove(ctx, app, addon.ID, opts.URL)
 			if err != nil {
-				io.Status("fail to remove the log drain from the addon:", addon.AddonProvider.Name, "\n\t", err)
+				// Check if this is a "not found" error, which can happen if the log drain
+				// was already removed by the main API call
+				if strings.Contains(err.Error(), "not found") {
+					io.Status("Log drain", opts.URL, "was already removed from the addon", addon.AddonProvider.Name)
+				} else {
+					io.Status("Unable to remove the log drain from the addon:", addon.AddonProvider.Name, "\n\t", err)
+				}
 			} else {
 				io.Status("Log drain", opts.URL, "has been deleted from the addon", addon.AddonProvider.Name)
 			}


### PR DESCRIPTION
This PR introduces OpenSearch support for log drains and improves error handling throughout the log drains functionality.

Changes:
- Add OpenSearch as a supported log drain type in documentation and examples
- Update ELK URL description to include OpenSearch as an option
- Migrate from errgo to go-utils/errors/v2 for better error handling
- Improve error messages to use action verbs for cleaner stacktraces
- Add specific handling for "not found" errors during log drain removal from addons for better feedback
- Clean up error handling flow in log drains removal logic


