### PR TITLE
[STORY-2189] Warn user before unscheduling periodic backups

### DIFF
--- a/cmd/alerts.go
+++ b/cmd/alerts.go
@@ -205,9 +205,8 @@ var (
 
 			utils.CheckForConsent(c.Context, currentApp, utils.ConsentTypeContainers)
 
-			disabled := false
 			err := alerts.Update(c.Context, currentApp, c.Args().First(), scalingo.AlertUpdateParams{
-				Disabled: &disabled,
+				Disabled: utils.BoolPtr(false),
 			})
 			if err != nil {
 				errorQuit(c.Context, err)
@@ -244,9 +243,8 @@ var (
 
 			utils.CheckForConsent(c.Context, currentApp, utils.ConsentTypeContainers)
 
-			disabled := true
 			err := alerts.Update(c.Context, currentApp, c.Args().First(), scalingo.AlertUpdateParams{
-				Disabled: &disabled,
+				Disabled: utils.BoolPtr(true),
 			})
 			if err != nil {
 				errorQuit(c.Context, err)

--- a/cmd/autocomplete/flags.go
+++ b/cmd/autocomplete/flags.go
@@ -62,7 +62,7 @@ func DisplayFlags(flags []cli.Flag) {
 
 	isBoolFlag := false
 	if _, ok := lastFlag.(*cli.BoolFlag); ok {
-		isBoolFlag = true && found
+		isBoolFlag = found
 	}
 
 	if !strings.HasPrefix(lastArg, "-") || isBoolFlag {

--- a/cmd/autoscalers.go
+++ b/cmd/autoscalers.go
@@ -171,9 +171,8 @@ var (
 
 			utils.CheckForConsent(c.Context, currentApp, utils.ConsentTypeContainers)
 
-			disabled := false
 			err := autoscalers.Update(c.Context, currentApp, c.Args().First(), scalingo.AutoscalerUpdateParams{
-				Disabled: &disabled,
+				Disabled: utils.BoolPtr(false),
 			})
 			if err != nil {
 				errorQuit(c.Context, err)
@@ -209,9 +208,8 @@ var (
 
 			utils.CheckForConsent(c.Context, currentApp, utils.ConsentTypeContainers)
 
-			disabled := true
 			err := autoscalers.Update(c.Context, currentApp, c.Args().First(), scalingo.AutoscalerUpdateParams{
-				Disabled: &disabled,
+				Disabled: utils.BoolPtr(true),
 			})
 			if err != nil {
 				errorQuit(c.Context, err)

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -115,6 +115,12 @@ var (
 			}
 
 			if disable {
+				continueB := askContinue("This operation will disable the periodic backups of a database. Are you sure?")
+				if !continueB {
+					errorQuit(c.Context, errors.New("unschedule operation was not confirmed"))
+					return nil
+				}
+
 				params.Enabled = utils.BoolPtr(false)
 			}
 			if scheduleAtFlag != "" {

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -115,12 +115,10 @@ var (
 			}
 
 			if disable {
-				f := false
-				params.Enabled = &f
+				params.Enabled = utils.BoolPtr(false)
 			}
 			if scheduleAtFlag != "" {
-				t := true
-				params.Enabled = &t
+				params.Enabled = utils.BoolPtr(true)
 				scheduleAt, loc, err := parseScheduleAtFlag(scheduleAtFlag)
 				if err != nil {
 					errorQuit(c.Context, err)

--- a/cmd/domains.go
+++ b/cmd/domains.go
@@ -86,8 +86,7 @@ var (
 					params.TLSKey = &keyContent
 				}
 				if c.Bool("no-letsencrypt") {
-					letsEncryptEnabled := false
-					params.LetsEncryptEnabled = &letsEncryptEnabled
+					params.LetsEncryptEnabled = utils.BoolPtr(false)
 				}
 
 				err = domains.Add(c.Context, currentApp, params)

--- a/cmd/integration_link.go
+++ b/cmd/integration_link.go
@@ -482,16 +482,15 @@ func interactiveCreate() (scalingo.SCMRepoLinkCreateParams, error) {
 		return params, errgo.Notef(err, "error enquiring about branch and automatic review apps deployment")
 	}
 
-	t := true
 	if answers.Branch != "" {
 		params.Branch = &answers.Branch
-		params.AutoDeployEnabled = &t
+		params.AutoDeployEnabled = utils.BoolPtr(true)
 	}
 	if !answers.AutoReviewApps {
 		return params, nil
 	}
 
-	params.DeployReviewAppsEnabled = &t
+	params.DeployReviewAppsEnabled = utils.BoolPtr(true)
 
 	destroyOnClose := true
 	err = survey.AskOne(&survey.Confirm{

--- a/cmd/log_drains.go
+++ b/cmd/log_drains.go
@@ -13,6 +13,8 @@ import (
 	"github.com/Scalingo/go-scalingo/v8"
 )
 
+const confirmDeletionSuffix = "\n\tConfirm deletion ?"
+
 var (
 	logDrainsListCommand = cli.Command{
 		Name:     "log-drains",
@@ -194,7 +196,7 @@ Warning: At the moment, only databases addons are able to forward logs to a drai
 				// app only
 				message += " for the application " + currentApp
 			}
-			result := askContinue(message)
+			result := askContinue(message + confirmDeletionSuffix)
 			if !result {
 				fmt.Println("Aborted")
 				return nil
@@ -221,7 +223,7 @@ Warning: At the moment, only databases addons are able to forward logs to a drai
 func askContinue(message string) bool {
 	result := false
 	prompt := &survey.Confirm{
-		Message: message + "\n\tConfirm deletion ?",
+		Message: message,
 	}
 	survey.AskOne(prompt, &result, nil)
 	return result

--- a/cmd/notifiers.go
+++ b/cmd/notifiers.go
@@ -171,11 +171,9 @@ var (
 
 			var active *bool
 			if c.IsSet("enable") {
-				tmpActive := true
-				active = &tmpActive
+				active = utils.BoolPtr(true)
 			} else if c.IsSet("disable") {
-				tmpActive := false
-				active = &tmpActive
+				active = utils.BoolPtr(false)
 			} else {
 				active = nil
 			}

--- a/integrationlink/params.go
+++ b/integrationlink/params.go
@@ -3,6 +3,7 @@ package integrationlink
 import (
 	"github.com/urfave/cli/v2"
 
+	"github.com/Scalingo/cli/utils"
 	"github.com/Scalingo/go-scalingo/v8"
 )
 
@@ -41,36 +42,30 @@ func (p *paramsChecker) lookupBranch() *string {
 
 func (p *paramsChecker) lookupAutoDeploy() *bool {
 	if p.ctx.IsSet("auto-deploy") {
-		t := true
-		return &t
+		return utils.BoolPtr(true)
 	}
 	if p.ctx.IsSet("no-auto-deploy") {
-		f := false
-		return &f
+		return utils.BoolPtr(false)
 	}
 	return nil
 }
 
 func (p *paramsChecker) lookupDeployReviewApps() *bool {
 	if p.ctx.IsSet("deploy-review-apps") {
-		t := true
-		return &t
+		return utils.BoolPtr(true)
 	}
 	if p.ctx.IsSet("no-deploy-review-apps") {
-		f := false
-		return &f
+		return utils.BoolPtr(false)
 	}
 	return nil
 }
 
 func (p *paramsChecker) lookupDestroyOnClose() *bool {
 	if p.ctx.IsSet("destroy-on-close") {
-		t := true
-		return &t
+		return utils.BoolPtr(true)
 	}
 	if p.ctx.IsSet("no-destroy-on-close") {
-		f := false
-		return &f
+		return utils.BoolPtr(false)
 	}
 	return nil
 }
@@ -86,24 +81,20 @@ func (p *paramsChecker) lookupHoursBeforeDestroyOnClose() *uint {
 
 func (p *paramsChecker) lookupDestroyOnStale() *bool {
 	if p.ctx.IsSet("destroy-on-stale") {
-		t := true
-		return &t
+		return utils.BoolPtr(true)
 	}
 	if p.ctx.IsSet("no-destroy-on-stale") {
-		f := false
-		return &f
+		return utils.BoolPtr(false)
 	}
 	return nil
 }
 
 func (p *paramsChecker) lookupAllowReviewAppsFromForks() *bool {
 	if p.ctx.IsSet("allow-review-apps-from-forks") {
-		t := true
-		return &t
+		return utils.BoolPtr(true)
 	}
 	if p.ctx.IsSet("no-allow-review-apps-from-forks") {
-		f := false
-		return &f
+		return utils.BoolPtr(false)
 	}
 	return nil
 }

--- a/utils/pointers.go
+++ b/utils/pointers.go
@@ -15,3 +15,7 @@ func Float64Ptr(r float64) *float64 {
 func StringPtr(r string) *string {
 	return &r
 }
+
+func BoolPtr(r bool) *bool {
+	return &r
+}


### PR DESCRIPTION
[STORY-2189](https://www.notion.so/scalingooriginal/FEAT-Warn-the-user-when-he-she-disables-an-automated-backup-CLI-225f536d89bf80c6b050c2dd86922a9e)

This story implements a new check to warn a user before unscheduling periodic backups. The user will now be prompted to confirm, or the command will fail.

I found [this](https://github.com/Scalingo/cli/blob/0856226f2ebbb73b49c10eb270f7aa8218b497bb/cmd/log_drains.go#L221) function that is used elsewhere to do the same thing.

Here are things that were done as well:
- Aligning several methods by using a `BoolPtr` function
- Refactoring `askContinue` to be more generic

State of the QA:
- [ ] Done