### PR TITLE
feat(domains): add 'Manual Action' column if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## To Be Released
 
 * feat(backups): prevent download of OpenSearch and Elasticsearch backups
+* feat(domains): add 'Manual Action' column if needed
 
 ### 1.38.0
 

--- a/cmd/domains.go
+++ b/cmd/domains.go
@@ -27,14 +27,16 @@ var (
 		}.Render(),
 
 		Action: func(ctx context.Context, c *cli.Command) error {
-			currentApp := detect.CurrentApp(c)
-			var err error
-			if c.Args().Len() == 0 {
-				err = domains.List(ctx, currentApp)
-			} else {
-				_ = cli.ShowCommandHelp(ctx, c, "domains")
+			if c.Args().Len() > 0 {
+				err := cli.ShowCommandHelp(c, "domains")
+				if err != nil {
+					errorQuit(ctx, err)
+				}
+				return nil
 			}
 
+			currentApp := detect.CurrentApp(c)
+			err := domains.List(ctx, currentApp)
 			if err != nil {
 				errorQuit(ctx, err)
 			}

--- a/domains/list.go
+++ b/domains/list.go
@@ -6,10 +6,10 @@ import (
 	"os"
 
 	"github.com/olekukonko/tablewriter"
-	"gopkg.in/errgo.v1"
 
 	"github.com/Scalingo/cli/config"
 	"github.com/Scalingo/go-scalingo/v8"
+	"github.com/Scalingo/go-utils/errors/v2"
 )
 
 var letsencryptStatusString = map[string]string{
@@ -23,11 +23,11 @@ var letsencryptStatusString = map[string]string{
 func List(ctx context.Context, app string) error {
 	c, err := config.ScalingoClient(ctx)
 	if err != nil {
-		return errgo.Notef(err, "fail to get Scalingo client")
+		return errors.Wrap(ctx, err, "fail to get Scalingo client")
 	}
 	domains, err := c.DomainsList(ctx, app)
 	if err != nil {
-		return errgo.Mask(err)
+		return errors.Wrap(ctx, err, "list domains")
 	}
 
 	t := tablewriter.NewWriter(os.Stdout)


### PR DESCRIPTION
Fix #1047

Output on a sample app:

```
go run ./scalingo --app my-app domains
┌──────────────────────────────────────────────┬───────────────┬──────────────────────────────────────────────────┬─────────────────────────────┬────────────────────────────────────────────────────────┐
│                    DOMAIN                    │   TLS / SSL   │                   TLS SUBJECT                    │ LET ' S ENCRYPT CERTIFICATE │                     MANUAL ACTION                      │
├──────────────────────────────────────────────┼───────────────┼──────────────────────────────────────────────────┼─────────────────────────────┼────────────────────────────────────────────────────────┤
│ redacted-domain.fr                           │ Let's Encrypt │ /CN=redacted-domain.fr                           │ Created                     │                                                        │
│ *.redacted-domain.fr                         │ -             │                                                  │ DNS required                │ _acme-challenge.redacted-domain.fr.                    │
│                                              │               │                                                  │                             │ redacted token                                         │
└──────────────────────────────────────────────┴───────────────┴──────────────────────────────────────────────────┴─────────────────────────────┴────────────────────────────────────────────────────────┘
```

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md