### PR TITLE
fix(privatenetworks): default format should be `table`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## To Be Released
 
-Some features listed in this changelog, like databases next generation, are currently only available in preview to 
+Some features listed in this changelog, like databases next generation, are currently only available in preview to
 selected users.
 
 * feat(databases next generation): create all commands to handle next generation `databases`.
+* fix(privatenetworks): default format should be `table`
 
 ## 1.40.0
 

--- a/cmd/privatenetworks.go
+++ b/cmd/privatenetworks.go
@@ -26,7 +26,7 @@ var (
 		Flags: []cli.Flag{&appFlag,
 			&cli.StringFlag{
 				Name:  "format",
-				Value: "json",
+				Value: outputFormatTable,
 				Usage: "[" + outputFormatJSON + "|" + outputFormatTable + "]",
 			},
 			&cli.StringFlag{


### PR DESCRIPTION
`table` is the default format in all the CLI. I think it should still be the same.

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md