### PR TITLE
feat(cmd) add database-list-plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* feat(cmd) add database-list-plans
+
 ## 1.43.2
 
 * fix(databases next generation): fix plan names in examples

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -318,6 +318,7 @@ var (
 		// Databases next generation
 		&databasesListCommand,
 		&databaseInfoCommand,
+		&databaseListPlansCommand,
 		&databaseCreateCommand,
 		&databaseUpgradeCommand,
 		&databaseDestroyCommand,

--- a/cmd/databases_ng.go
+++ b/cmd/databases_ng.go
@@ -77,6 +77,36 @@ var (
 		},
 	}
 
+	databaseListPlansCommand = cli.Command{
+		Name:     "database-list-plans",
+		Category: "Databases DR",
+		Usage:    "List the available plans for database Dedicated Resources",
+		Description: CommandDescription{
+			Description: "List all the available plans for database Dedicated Resources",
+			Examples: []string{
+				"scalingo database-list-plans postgresql-ng",
+			},
+			SeeAlso: []string{"databases", "database-info", "database-create", "database-upgrade", "database-destroy"},
+		}.Render(),
+		Action: func(ctx context.Context, c *cli.Command) error {
+			technology := c.Args().First()
+			if technology == "" {
+				io.Error("Please provide a database technology")
+				return cli.ShowCommandHelp(ctx, c, "database-list-plans")
+			}
+
+			err := dbng.ListPlans(ctx, technology)
+			if err != nil {
+				errorQuit(ctx, err)
+			}
+
+			return nil
+		},
+		ShellComplete: func(_ context.Context, c *cli.Command) {
+			_ = autocomplete.CmdFlagsAutoComplete(c, "database-list-plans")
+		},
+	}
+
 	databaseCreateCommand = cli.Command{
 		Name:      "database-create",
 		Category:  "Databases DR",

--- a/dbng/list_plans.go
+++ b/dbng/list_plans.go
@@ -1,0 +1,16 @@
+package dbng
+
+import (
+	"context"
+
+	"github.com/Scalingo/cli/addonproviders"
+	"github.com/Scalingo/go-utils/errors/v2"
+)
+
+func ListPlans(ctx context.Context, technology string) error {
+	err := addonproviders.Plans(ctx, technology)
+	if err != nil {
+		return errors.Wrap(ctx, err, "list the plans of the database")
+	}
+	return nil
+}


### PR DESCRIPTION
```sh
➜  scalingo database-list-plans postgresql-ng
┌────────────────────────────────────┬────────────────────┐
│                 ID                 │        NAME        │
├────────────────────────────────────┼────────────────────┤
│ postgresql-ng-starter-1024         │ Starter 1G         │
│ postgresql-dr-starter-4096         │ Starter 4G         │
│ postgresql-dr-business-4096        │ Business 4G        │
│ postgresql-ng-enterprise-4096      │ Enterprise 4G      │
└────────────────────────────────────┴────────────────────┘
```

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md