### PR TITLE
fix(error): remove incorrect negation

### DIFF
--- a/cmd/error.go
+++ b/cmd/error.go
@@ -160,7 +160,7 @@ func newReportError(currentUser *scalingo.User, err error) *ReportError {
 	}
 
 	var requestFailedError *httpclient.RequestFailedError
-	if !errors.As(err, &requestFailedError) {
+	if errors.As(err, &requestFailedError) {
 		r.FailedRequest = requestFailedError.Req.HTTPRequest
 	}
 


### PR DESCRIPTION
In https://github.com/Scalingo/cli/pull/1198, we updated how we check if the error is a `RequestFailedError`. For some reason, a negation (`!`) has been added..

Related to #1155 

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md