### PR TITLE
fix(run): correctly parse operation URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* fix(run): correctly parse operation URL
+
 ## 1.44.0
 
 * build(deps): update `github.com/Scalingo/go-scalingo` from v9 to v11
@@ -13,7 +15,6 @@
 * feat(apps/create): detect Git main branch name
 * fix(databases): `parseScheduleAtFlag` returns a validation error
 * fix(privatenetworks): `PrivateNetworksDomainsList` must take a `pagination.Request` in argument
-* build(deps): update `github.com/Scalingo/go-scalingo` from v10 to v11
 * fix(run): avoid a panic when polling one-off operations fails
 
 ## 1.43.3

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
-	github.com/Scalingo/go-scalingo/v11 v11.0.0
+	github.com/Scalingo/go-scalingo/v11 v11.0.3
 	github.com/Scalingo/go-utils/errors/v3 v3.2.0
 	github.com/Scalingo/go-utils/logger v1.12.1
 	github.com/Scalingo/go-utils/pagination v1.2.0
@@ -24,6 +24,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/stvp/rollbar v0.5.1
 	github.com/urfave/cli/v3 v3.8.0
+	go.uber.org/mock v0.6.0
 	golang.org/x/crypto v0.49.0
 	golang.org/x/term v0.41.0
 	golang.org/x/text v0.35.0
@@ -64,7 +65,6 @@ require (
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
-	go.uber.org/mock v0.6.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	gopkg.in/errgo.v1 v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/Scalingo/go-scalingo/v11 v11.0.0 h1:URWRLO4mK+06WMfA6065vVwKIL0k4146RCiZuxARWp4=
-github.com/Scalingo/go-scalingo/v11 v11.0.0/go.mod h1:SKmfy5pA4i9jb6Zxx5n2X9uh9Q7Hwkr1sCDICA/3Z4U=
+github.com/Scalingo/go-scalingo/v11 v11.0.3 h1:CcrjEWjPiXjc92RKH3o9qziqwSH0QFUGgYx4jr4hnb8=
+github.com/Scalingo/go-scalingo/v11 v11.0.3/go.mod h1:NHldjCv/tYLyTs5ed7kGVMvuCtoP2W8Lfhcnhm8Sl0Q=
 github.com/Scalingo/go-utils/errors/v3 v3.2.0 h1:Ks+v2oRwv3VZfe+xVB+kpfmZouXHVCPHHtwL5W60prc=
 github.com/Scalingo/go-utils/errors/v3 v3.2.0/go.mod h1:jVVNoOdYFjuNkR/BeEZWNWJVvu4jmyLY4udlsQQyBss=
 github.com/Scalingo/go-utils/logger v1.12.1 h1:r+RqwOcnsTtKoQdvcNVZCtu0Xhq01tp/3gT6+4Q7AxI=

--- a/vendor/github.com/Scalingo/go-scalingo/v11/CHANGELOG.md
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## To Be Released
 
+## 11.0.3
+
+* fix(run): add JSON tag for `OperationURL`
+
+## 11.0.2
+
+* feat(EventRestart): add `Reason` field
+
+## 11.0.1
+
+* chore(deps): bump `golang.org/x/text` from `0.34.0` to `0.35.0` ([#494](https://github.com/Scalingo/go-scalingo/pull/494))
+* build: align Dockerfile Go version with `go.mod` ([#494](https://github.com/Scalingo/go-scalingo/pull/494))
+
 ## 11.0.0
 
 * fix(privatenetworks): `PrivateNetworksDomainsList` must take a `pagination.Request` in argument (breaking change)

--- a/vendor/github.com/Scalingo/go-scalingo/v11/Dockerfile
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24
+FROM golang:1.25
 MAINTAINER Étienne Michon "etienne@scalingo.com"
 
 RUN go install github.com/cespare/reflex@latest

--- a/vendor/github.com/Scalingo/go-scalingo/v11/README.md
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/README.md
@@ -1,4 +1,4 @@
-# Go client for Scalingo API v11.0.0
+# Go client for Scalingo API v11.0.3
 
 This repository is the Go client for the [Scalingo APIs](https://developers.scalingo.com/).
 
@@ -81,7 +81,7 @@ Bump new version number in:
 Commit, tag and create a new release:
 
 ```sh
-version="11.0.0"
+version="11.0.3"
 
 git switch --create release/${version}
 git add CHANGELOG.md README.md version.go

--- a/vendor/github.com/Scalingo/go-scalingo/v11/events_app.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/events_app.go
@@ -106,8 +106,9 @@ func (ev *EventTransferAppType) String() string {
 }
 
 type EventRestartTypeData struct {
-	Scope     []string `json:"scope"`
-	AddonName string   `json:"addon_name"`
+	Scope     []string               `json:"scope"`
+	AddonName string                 `json:"addon_name"`
+	Reason    ContainerRestartReason `json:"reason"`
 }
 
 type EventRestartType struct {
@@ -116,11 +117,37 @@ type EventRestartType struct {
 	TypeData EventRestartTypeData `json:"type_data"`
 }
 
+// ContainerRestartReason identifies the logical origin of a restart request
+type ContainerRestartReason string
+
+const (
+	ContainerRestartReasonUserRestart          ContainerRestartReason = "user_restart"
+	ContainerRestartReasonUnexpectedFailure    ContainerRestartReason = "unexpected_failure"
+	ContainerRestartReasonRebalancingOperation ContainerRestartReason = "rebalancing_operation"
+	ContainerRestartReasonSecurityMaintenance  ContainerRestartReason = "security_maintenance"
+)
+
 func (ev *EventRestartType) String() string {
+	message := "containers began to restart"
 	if len(ev.TypeData.Scope) != 0 {
-		return fmt.Sprintf("containers %v began to restart", ev.TypeData.Scope)
+		message = fmt.Sprintf("containers %v began to restart", ev.TypeData.Scope)
 	}
-	return "containers began to restart"
+	if ev.TypeData.Reason != "" {
+		reason := ev.TypeData.Reason
+		switch ev.TypeData.Reason {
+		case ContainerRestartReasonUserRestart:
+			reason = "user restart"
+		case ContainerRestartReasonUnexpectedFailure:
+			reason = "unexpected failure"
+		case ContainerRestartReasonRebalancingOperation:
+			reason = "infrastructure rebalancing operation"
+		case ContainerRestartReasonSecurityMaintenance:
+			reason = "scheduled security maintenance"
+		}
+
+		message = fmt.Sprintf("%s (reason: %s)", message, reason)
+	}
+	return message
 }
 
 func (ev *EventRestartType) Who() string {

--- a/vendor/github.com/Scalingo/go-scalingo/v11/run.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/run.go
@@ -26,7 +26,7 @@ type RunOpts struct {
 type RunRes struct {
 	Container    *Container `json:"container"`
 	AttachURL    string     `json:"attach_url"`
-	OperationURL string     `json:"-"`
+	OperationURL string     `json:"operation_url"`
 }
 
 func (c *Client) Run(ctx context.Context, opts RunOpts) (*RunRes, error) {

--- a/vendor/github.com/Scalingo/go-scalingo/v11/version.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "11.0.0"
+var Version = "11.0.3"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -37,8 +37,8 @@ github.com/ProtonMail/go-crypto/openpgp/packet
 github.com/ProtonMail/go-crypto/openpgp/s2k
 github.com/ProtonMail/go-crypto/openpgp/x25519
 github.com/ProtonMail/go-crypto/openpgp/x448
-# github.com/Scalingo/go-scalingo/v11 v11.0.0
-## explicit; go 1.24.0
+# github.com/Scalingo/go-scalingo/v11 v11.0.3
+## explicit; go 1.25.0
 github.com/Scalingo/go-scalingo/v11
 github.com/Scalingo/go-scalingo/v11/billing
 github.com/Scalingo/go-scalingo/v11/debug


### PR DESCRIPTION


```
bsscalingo --app biniou run bash
-----> Starting container one-off-3487  Done in 0.117 seconds
-----> Connecting to container [one-off-3487]...  
-----> Process 'bash' is starting...  
[...]
[13:13][osc-st-fr1] Scalingo:biniou ~ $ 
```

Fix #1214

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md