### PR TITLE
feat(session): remove region cache on logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* feat(session): remove region cache on logout
+
 ## 1.44.1
 
 * fix(run): correctly parse operation URL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## To Be Released
 
 * fix(addons): parse `maintenance-window-hour` as an int
+* feat(session): remove region cache on logout
 
 ## 1.44.1
 

--- a/config/region.go
+++ b/config/region.go
@@ -137,3 +137,12 @@ func GetRegion(ctx context.Context, c Config, name string, opts GetRegionOpts) (
 	}
 	return scalingo.Region{}, UnknownRegionError{regionName: name}
 }
+
+func DeleteRegionsCache(ctx context.Context, c Config) error {
+	err := os.Remove(c.RegionsCachePath)
+	if err != nil && !os.IsNotExist(err) {
+		return errors.Wrapf(ctx, err, "remove region cache %s", c.RegionsCachePath)
+	}
+
+	return nil
+}

--- a/session/destroy.go
+++ b/session/destroy.go
@@ -13,5 +13,10 @@ func DestroyToken(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(ctx, err, "remove local authentication credentials")
 	}
+
+	err = config.DeleteRegionsCache(ctx, config.C)
+	if err != nil {
+		return errors.Wrap(ctx, err, "remove local regions cache")
+	}
 	return nil
 }

--- a/session/destroy.go
+++ b/session/destroy.go
@@ -13,5 +13,15 @@ func DestroyToken(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(ctx, err, "remove local authentication credentials")
 	}
+
+	// We want to delete the regions cache so that the cache is created again during the next login.
+	// This is important for people with two different Scalingo accounts, one with and one without access to the osc-secnum-fr1 region.
+	// If we don't, there is a risk that when the client login with the osc-secnum-fr1 account, the regions cache does not contain the osc-secnum-fr1 region and client cannot contact this region.
+	// Ref. https://github.com/Scalingo/cli/issues/1057
+	err = config.DeleteRegionsCache(ctx, config.C)
+	if err != nil {
+		return errors.Wrap(ctx, err, "remove local regions cache")
+	}
+
 	return nil
 }


### PR DESCRIPTION
How I tested the fix:
1. `scalingo login --password-only` using an account with no access to osc-secnum-fr1
2. `bscalingo logout` with the CLI version from this branch
3. `bscalingo login` using an account with access to osc-secnum-fr1
4. `bscalingo --app my-test-app --region osc-secnum-fr1 timeline`

At this point, the latest release is impacted by a bug which displays:

```
 !     An error occurred:                                                                                                                                                                                                                                     
       invalid region osc-secnum-fr1                                                                                                                                                                                                                          
```

With the version from this branch, it works with no problem.

fix #1057 

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md