### PR TITLE
fix(addons): parse `maintenance-window-hour` as an int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* fix(addons): parse `maintenance-window-hour` as an int
+
 ## 1.44.1
 
 * fix(run): correctly parse operation URL

--- a/cmd/addons.go
+++ b/cmd/addons.go
@@ -199,21 +199,21 @@ var (
 
 			currentApp := detect.CurrentApp(ctx, c)
 			currentAddon := c.Args().First()
-			config := addons.UpdateAddonConfigOpts{}
+			updateAddonConfig := addons.UpdateAddonConfigOpts{}
 
 			if c.IsSet("maintenance-window-day") {
-				config.MaintenanceWindowDay = utils.StringPtr(c.String("maintenance-window-day"))
+				updateAddonConfig.MaintenanceWindowDay = utils.StringPtr(c.String("maintenance-window-day"))
 			}
 
 			if c.IsSet("maintenance-window-hour") {
-				config.MaintenanceWindowHour = utils.IntPtr(c.Int("maintenance-window-hour"))
+				updateAddonConfig.MaintenanceWindowHour = utils.IntPtr(c.Int("maintenance-window-hour"))
 			}
 
-			if config.MaintenanceWindowHour == nil && config.MaintenanceWindowDay == nil {
+			if updateAddonConfig.MaintenanceWindowHour == nil && updateAddonConfig.MaintenanceWindowDay == nil {
 				errorQuitWithHelpMessage(ctx, errors.New(ctx, "cannot update your addon without a specified option"), c, "addons-config")
 			}
 
-			err := addons.UpdateConfig(ctx, currentApp, currentAddon, config)
+			err := addons.UpdateConfig(ctx, currentApp, currentAddon, updateAddonConfig)
 			if err != nil {
 				errorQuit(ctx, err)
 			}

--- a/cmd/addons.go
+++ b/cmd/addons.go
@@ -183,7 +183,7 @@ var (
 		Category: "Addons",
 		Usage:    "Configure an add-on attached to your app",
 		Flags: []cli.Flag{&appFlag,
-			&cli.StringFlag{Name: "maintenance-window-hour", Usage: "Configure add-on maintenance window starting hour (in your local timezone)"},
+			&cli.IntFlag{Name: "maintenance-window-hour", Usage: "Configure add-on maintenance window starting hour (in your local timezone)"},
 			&cli.StringFlag{Name: "maintenance-window-day", Usage: "Configure add-on maintenance window day"},
 		},
 		ArgsUsage: "addon-id",


### PR DESCRIPTION
```
bsscalingo --app REDACTED addons-config ad-REDACTED --maintenance-window-hour 3
Addon config updated.
```

And now on the dashboard:

<img width="1253" height="169" alt="image" src="https://github.com/user-attachments/assets/2e4be132-3ecd-4f69-afe4-3869db190f19" />


Fix #1219 

- [x] Add a changelog entry in the section "To Be Released" of CHANGELOG.md