### PR TITLE
feat(pitr): add command to restore a database to a specific point in time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* feat(pitr): add command to restore a database to a specific point in time
+
 ## v1.47.0
 
 * chore(deps/go-scalingo): update go-scalingo to add support of continuousbackup events

--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ COMMANDS:
    Notifiers - Global:
      notification-platforms  List all notification platforms
 
+   PITR management:
+     database-pitr-restore  Restore a database to a specific point in time
+
    Private Networks:
      private-networks-domain-names  List the private network domain names of an application
 
@@ -243,6 +246,7 @@ COMMANDS:
 GLOBAL OPTIONS:
    --addon string              ID of the current addon (default: "<addon_id>") [$SCALINGO_ADDON]
    --app string, -a string     Name of the app (default: "<name>") [$SCALINGO_APP]
+   --format string             [json|table] (default: "table")
    --remote string, -r string  Name of the remote (default: "scalingo")
    --region string             Name of the region to use
    --help, -h                  show help

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -269,6 +269,9 @@ var (
 		&databaseMaintenanceList,
 		&databaseMaintenanceInfo,
 
+		// PITR
+		&databasePITRRestore,
+
 		// Backups
 		&backupsListCommand,
 		&backupsCreateCommand,

--- a/cmd/pitr.go
+++ b/cmd/pitr.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"context"
+	"time"
+
+	"github.com/Scalingo/go-utils/errors/v3"
+	"github.com/urfave/cli/v3"
+
+	"github.com/Scalingo/cli/db/pitr"
+	"github.com/Scalingo/cli/detect"
+	"github.com/Scalingo/cli/utils"
+)
+
+var databasePITRRestore = cli.Command{
+	Name:      "database-pitr-restore",
+	Category:  "PITR management",
+	Usage:     "Restore a database to a specific point in time",
+	ArgsUsage: "restore-time",
+	Flags: []cli.Flag{
+		&appFlag,
+		&addonFlag,
+	},
+	Description: CommandDescription{
+		Description: "Restore a database to a specific point in time",
+		Examples: []string{
+			"scalingo --app my-app --addon my-addon database-pitr-restore 2026-07-18T23:00:00Z",
+		},
+	}.Render(),
+	Action: func(ctx context.Context, c *cli.Command) error {
+		currentResource, currentDatabase := detect.GetCurrentResourceAndDatabase(ctx, c)
+
+		utils.CheckForConsent(ctx, currentResource, utils.ConsentTypeDBs)
+		addonName := currentDatabase
+		if currentDatabase == "" {
+			addonName = addonUUIDFromFlags(ctx, c, currentResource, true)
+		}
+
+		restoreTimeStr, err := time.Parse(time.RFC3339, c.Args().First())
+		if err != nil {
+			errorQuitWithHelpMessage(ctx, errors.Wrap(ctx, err, "invalid restore-time format"), c, "database-pitr-restore")
+		}
+
+		err = pitr.Restore(ctx, currentResource, addonName, restoreTimeStr)
+		if err != nil {
+			errorQuit(ctx, err)
+		}
+
+		return nil
+	},
+}

--- a/cmd/pitr.go
+++ b/cmd/pitr.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/Scalingo/go-utils/errors/v3"
 	"github.com/urfave/cli/v3"
 
 	"github.com/Scalingo/cli/db/pitr"
 	"github.com/Scalingo/cli/detect"
 	"github.com/Scalingo/cli/utils"
+	"github.com/Scalingo/go-utils/errors/v3"
 )
 
 var databasePITRRestore = cli.Command{

--- a/db/maintenance/list.go
+++ b/db/maintenance/list.go
@@ -17,12 +17,12 @@ import (
 func List(ctx context.Context, app string, addonName string, paginationReq pagination.Request) error {
 	c, err := config.ScalingoClient(ctx)
 	if err != nil {
-		return errors.Wrapf(ctx, err, "get Scalingo client")
+		return errors.Wrap(ctx, err, "get Scalingo client")
 	}
 
 	maintenances, pagination, err := c.DatabaseListMaintenance(ctx, app, addonName, paginationReq)
 	if err != nil {
-		return errors.Wrapf(ctx, err, "list the database maintenance")
+		return errors.Wrap(ctx, err, "list the database maintenance")
 	}
 
 	t := tablewriter.NewWriter(os.Stdout)
@@ -41,7 +41,7 @@ func List(ctx context.Context, app string, addonName string, paginationReq pagin
 
 		t.Append([]string{
 			maintenance.ID,
-			string(maintenance.Type),
+			maintenance.Type,
 			startedAt,
 			endedAt,
 			string(maintenance.Status),

--- a/db/pitr/restore.go
+++ b/db/pitr/restore.go
@@ -2,6 +2,7 @@ package pitr
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/Scalingo/cli/config"
@@ -13,6 +14,15 @@ func Restore(ctx context.Context, currentResource, addonName string, restoreTime
 	c, err := config.ScalingoClient(ctx)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "get Scalingo client")
+	}
+
+	io.Warning("This operation is irreversible and previous data will be restore")
+	io.Info("Do you want to confirm? (y/n)")
+
+	var confirm string
+	_, _ = fmt.Scanln(&confirm)
+	if confirm != "y" && confirm != "Y" {
+		return errors.New(ctx, "You didn't confirm, aborting…")
 	}
 
 	operationID, err := c.DatabaseRestorePITR(ctx, currentResource, addonName, restoreTime)

--- a/db/pitr/restore.go
+++ b/db/pitr/restore.go
@@ -1,0 +1,26 @@
+package pitr
+
+import (
+	"context"
+	"time"
+
+	"github.com/Scalingo/cli/config"
+	"github.com/Scalingo/cli/io"
+	"github.com/Scalingo/go-utils/errors/v3"
+)
+
+func Restore(ctx context.Context, currentResource, addonName string, restoreTime time.Time) error {
+	c, err := config.ScalingoClient(ctx)
+	if err != nil {
+		return errors.Wrapf(ctx, err, "get Scalingo client")
+	}
+
+	operationID, err := c.DatabasePITRRestore(ctx, currentResource, addonName, restoreTime)
+	if err != nil {
+		return errors.Wrap(ctx, err, "restore database")
+	}
+
+	io.Statusf("Database restore operation %s has been created", operationID)
+
+	return nil
+}

--- a/db/pitr/restore.go
+++ b/db/pitr/restore.go
@@ -20,7 +20,7 @@ func Restore(ctx context.Context, currentResource, addonName string, restoreTime
 		return errors.Wrap(ctx, err, "restore database")
 	}
 
-	io.Statusf("Database restore operation %s has been created", operationID)
+	io.Statusf("Database restore operation %s has been created\n", operationID)
 
 	return nil
 }

--- a/db/pitr/restore.go
+++ b/db/pitr/restore.go
@@ -15,7 +15,7 @@ func Restore(ctx context.Context, currentResource, addonName string, restoreTime
 		return errors.Wrapf(ctx, err, "get Scalingo client")
 	}
 
-	operationID, err := c.DatabasePITRRestore(ctx, currentResource, addonName, restoreTime)
+	operationID, err := c.DatabaseRestorePITR(ctx, currentResource, addonName, restoreTime)
 	if err != nil {
 		return errors.Wrap(ctx, err, "restore database")
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
-	github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260804160306-6c1691e7ad1f
+	github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260806084722-668209583641
 	github.com/Scalingo/go-utils/errors/v3 v3.2.1
 	github.com/Scalingo/go-utils/logger v1.12.2
 	github.com/Scalingo/go-utils/pagination v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
-	github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260806084722-668209583641
+	github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260810154739-f30bd2e7ef2c
 	github.com/Scalingo/go-utils/errors/v3 v3.2.1
 	github.com/Scalingo/go-utils/logger v1.12.2
 	github.com/Scalingo/go-utils/pagination v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
-	github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260810154739-f30bd2e7ef2c
+	github.com/Scalingo/go-scalingo/v11 v11.2.0
 	github.com/Scalingo/go-utils/errors/v3 v3.2.1
 	github.com/Scalingo/go-utils/logger v1.12.2
 	github.com/Scalingo/go-utils/pagination v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
-	github.com/Scalingo/go-scalingo/v11 v11.1.1
+	github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260804160306-6c1691e7ad1f
 	github.com/Scalingo/go-utils/errors/v3 v3.2.1
 	github.com/Scalingo/go-utils/logger v1.12.2
 	github.com/Scalingo/go-utils/pagination v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260806084722-668209583641 h1:HrpskeN9yVkF5Gm5jH2VL0fAvJsZvDZ0zJt7nsrE5Jw=
-github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260806084722-668209583641/go.mod h1:188AcoLrztIhk3BQPaYHKJesSYXxBwWQvKWQoewKww0=
+github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260810154739-f30bd2e7ef2c h1:5Top2k2FhWxdHEjjS8a15Tj1bxdgpgUataENMfCpOgw=
+github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260810154739-f30bd2e7ef2c/go.mod h1:188AcoLrztIhk3BQPaYHKJesSYXxBwWQvKWQoewKww0=
 github.com/Scalingo/go-utils/errors/v3 v3.2.1 h1:2w3qUz6MxJa3aqx/biz2G3JquSKsFnfz/E7wrNf/LPc=
 github.com/Scalingo/go-utils/errors/v3 v3.2.1/go.mod h1:jVVNoOdYFjuNkR/BeEZWNWJVvu4jmyLY4udlsQQyBss=
 github.com/Scalingo/go-utils/logger v1.12.2 h1:9vm83/gqjCIy5t+OuNYjkVOUrJtdMy78XNIv8E+OCCU=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260810154739-f30bd2e7ef2c h1:5Top2k2FhWxdHEjjS8a15Tj1bxdgpgUataENMfCpOgw=
-github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260810154739-f30bd2e7ef2c/go.mod h1:188AcoLrztIhk3BQPaYHKJesSYXxBwWQvKWQoewKww0=
+github.com/Scalingo/go-scalingo/v11 v11.2.0 h1:H3aHtKAEo1ZMoRU8YoCUqnt3REOkKnyfMqE8Q9ZVTr0=
+github.com/Scalingo/go-scalingo/v11 v11.2.0/go.mod h1:188AcoLrztIhk3BQPaYHKJesSYXxBwWQvKWQoewKww0=
 github.com/Scalingo/go-utils/errors/v3 v3.2.1 h1:2w3qUz6MxJa3aqx/biz2G3JquSKsFnfz/E7wrNf/LPc=
 github.com/Scalingo/go-utils/errors/v3 v3.2.1/go.mod h1:jVVNoOdYFjuNkR/BeEZWNWJVvu4jmyLY4udlsQQyBss=
 github.com/Scalingo/go-utils/logger v1.12.2 h1:9vm83/gqjCIy5t+OuNYjkVOUrJtdMy78XNIv8E+OCCU=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260804160306-6c1691e7ad1f h1:hBBL11QLuLajmSa29GBkUnMveFHOE2FmhuLbD/ntVLQ=
-github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260804160306-6c1691e7ad1f/go.mod h1:188AcoLrztIhk3BQPaYHKJesSYXxBwWQvKWQoewKww0=
+github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260806084722-668209583641 h1:HrpskeN9yVkF5Gm5jH2VL0fAvJsZvDZ0zJt7nsrE5Jw=
+github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260806084722-668209583641/go.mod h1:188AcoLrztIhk3BQPaYHKJesSYXxBwWQvKWQoewKww0=
 github.com/Scalingo/go-utils/errors/v3 v3.2.1 h1:2w3qUz6MxJa3aqx/biz2G3JquSKsFnfz/E7wrNf/LPc=
 github.com/Scalingo/go-utils/errors/v3 v3.2.1/go.mod h1:jVVNoOdYFjuNkR/BeEZWNWJVvu4jmyLY4udlsQQyBss=
 github.com/Scalingo/go-utils/logger v1.12.2 h1:9vm83/gqjCIy5t+OuNYjkVOUrJtdMy78XNIv8E+OCCU=

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/Scalingo/go-scalingo/v11 v11.1.1 h1:INyoLmn8mLZYIN1JVSmI9e0P9bnYsMeAIqC/ZByWUWI=
-github.com/Scalingo/go-scalingo/v11 v11.1.1/go.mod h1:lH/1yV+WQ+Vi5ByGYNJRcWQkHKLaq/vtqZaQavwi3ZA=
+github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260804160306-6c1691e7ad1f h1:hBBL11QLuLajmSa29GBkUnMveFHOE2FmhuLbD/ntVLQ=
+github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260804160306-6c1691e7ad1f/go.mod h1:188AcoLrztIhk3BQPaYHKJesSYXxBwWQvKWQoewKww0=
 github.com/Scalingo/go-utils/errors/v3 v3.2.1 h1:2w3qUz6MxJa3aqx/biz2G3JquSKsFnfz/E7wrNf/LPc=
 github.com/Scalingo/go-utils/errors/v3 v3.2.1/go.mod h1:jVVNoOdYFjuNkR/BeEZWNWJVvu4jmyLY4udlsQQyBss=
 github.com/Scalingo/go-utils/logger v1.12.2 h1:9vm83/gqjCIy5t+OuNYjkVOUrJtdMy78XNIv8E+OCCU=

--- a/projects/add.go
+++ b/projects/add.go
@@ -20,7 +20,7 @@ func Add(ctx context.Context, params scalingo.ProjectAddParams) error {
 		return errors.Wrap(ctx, err, "add project")
 	}
 
-	io.Status(project.Name, "has been created")
+	io.Status(project.Name, "has been created\n")
 
 	return nil
 }

--- a/projects/update.go
+++ b/projects/update.go
@@ -20,7 +20,7 @@ func Update(ctx context.Context, projectID string, params scalingo.ProjectUpdate
 		return errors.Wrap(ctx, err, "update project")
 	}
 
-	io.Status(project.Name, "has been updated")
+	io.Status(project.Name, "has been updated\n")
 
 	return nil
 }

--- a/vendor/github.com/Scalingo/go-scalingo/v11/CHANGELOG.md
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* feat(databases): Add new method to restore PITR
+
 ## 11.1.1
 
 * feat(events): add database continuous backup events

--- a/vendor/github.com/Scalingo/go-scalingo/v11/CHANGELOG.md
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## To Be Released
 
+* fix(databases): Fix PITR restore return
 * feat(databases): Add new method to restore PITR
 
 ## 11.1.1

--- a/vendor/github.com/Scalingo/go-scalingo/v11/CHANGELOG.md
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+## 11.2.0
+
 * fix(databases): Fix PITR restore return
 * feat(databases): Add new method to restore PITR
 

--- a/vendor/github.com/Scalingo/go-scalingo/v11/README.md
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/README.md
@@ -1,4 +1,4 @@
-# Go client for Scalingo API v11.1.1
+# Go client for Scalingo API v11.2.0
 
 This repository is the Go client for the [Scalingo APIs](https://developers.scalingo.com/).
 
@@ -81,7 +81,7 @@ Bump new version number in:
 Commit, tag and create a new release:
 
 ```sh
-version="11.1.1"
+version="11.2.0"
 
 git switch --create release/${version}
 git add CHANGELOG.md README.md version.go

--- a/vendor/github.com/Scalingo/go-scalingo/v11/databases.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/databases.go
@@ -20,6 +20,7 @@ type DatabasesService interface {
 	DatabaseUpdateMaintenanceWindow(ctx context.Context, app, addonID string, params MaintenanceWindowParams) (Database, error)
 	DatabaseListMaintenance(ctx context.Context, app, addonID string, paginationReq pagination.Request) ([]*Maintenance, pagination.Meta, error)
 	DatabaseShowMaintenance(ctx context.Context, app, addonID, maintenanceID string) (Maintenance, error)
+	DatabasePITRRestore(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error)
 }
 
 // DatabaseStatus is a string representing the status of a database deployment
@@ -333,4 +334,31 @@ func (c *Client) DatabaseUserResetPassword(ctx context.Context, app, addonID, us
 	}
 
 	return res.DatabaseUser, nil
+}
+
+type databasePITRRestorePayload struct {
+	RestoreTime time.Time `json:"restore_time"`
+}
+
+// databasePITRRestoreRes is the response body of database PITR restore.
+type databasePITRRestoreRes struct {
+	OperationID string `json:"operation_id"`
+}
+
+// DatabasePITRRestore asks for a PiTR restore of the given addon/database.
+// It returns the linked operation ID.
+func (c *Client) DatabasePITRRestore(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error) {
+	var res databasePITRRestoreRes
+	req := &httpclient.APIRequest{
+		Method:   http.MethodPost,
+		Endpoint: "/" + databasesResource + "/" + addonID + "/pitr/restore",
+		Expected: httpclient.Statuses{http.StatusCreated},
+		Params:   databasePITRRestorePayload{RestoreTime: restoreTime},
+	}
+	err := c.DBAPI(app, addonID).DoRequest(ctx, req, &res)
+	if err != nil {
+		return "", err
+	}
+
+	return res.OperationID, nil
 }

--- a/vendor/github.com/Scalingo/go-scalingo/v11/databases.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/databases.go
@@ -342,7 +342,7 @@ type databaseRestorePITRPayload struct {
 
 // databaseRestorePITRRes is the response body of database PITR restore.
 type databaseRestorePITRRes struct {
-	OperationID string `json:"operation_id"`
+	Operation Operation `json:"operation"`
 }
 
 // DatabaseRestorePITR asks for a PITR restore of the given addon/database.
@@ -360,5 +360,5 @@ func (c *Client) DatabaseRestorePITR(ctx context.Context, app, addonID string, r
 		return "", err
 	}
 
-	return res.OperationID, nil
+	return res.Operation.ID, nil
 }

--- a/vendor/github.com/Scalingo/go-scalingo/v11/databases.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/databases.go
@@ -20,7 +20,7 @@ type DatabasesService interface {
 	DatabaseUpdateMaintenanceWindow(ctx context.Context, app, addonID string, params MaintenanceWindowParams) (Database, error)
 	DatabaseListMaintenance(ctx context.Context, app, addonID string, paginationReq pagination.Request) ([]*Maintenance, pagination.Meta, error)
 	DatabaseShowMaintenance(ctx context.Context, app, addonID, maintenanceID string) (Maintenance, error)
-	DatabasePITRRestore(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error)
+	DatabaseRestorePITR(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error)
 }
 
 // DatabaseStatus is a string representing the status of a database deployment
@@ -179,7 +179,7 @@ const (
 	DatabaseFeatureStatusActivated DatabaseFeatureStatus = "ACTIVATED"
 	// DatabaseFeatureStatusPending is set when the feature is being enabled
 	DatabaseFeatureStatusPending DatabaseFeatureStatus = "PENDING"
-	// DatabaseFeatureStatusFailed is set when the feature failed to get enabeld
+	// DatabaseFeatureStatusFailed is set when the feature failed to get enabled
 	DatabaseFeatureStatusFailed DatabaseFeatureStatus = "FAILED"
 )
 
@@ -336,24 +336,24 @@ func (c *Client) DatabaseUserResetPassword(ctx context.Context, app, addonID, us
 	return res.DatabaseUser, nil
 }
 
-type databasePITRRestorePayload struct {
+type databaseRestorePITRPayload struct {
 	RestoreTime time.Time `json:"restore_time"`
 }
 
-// databasePITRRestoreRes is the response body of database PITR restore.
-type databasePITRRestoreRes struct {
+// databaseRestorePITRRes is the response body of database PITR restore.
+type databaseRestorePITRRes struct {
 	OperationID string `json:"operation_id"`
 }
 
-// DatabasePITRRestore asks for a PiTR restore of the given addon/database.
+// DatabaseRestorePITR asks for a PITR restore of the given addon/database.
 // It returns the linked operation ID.
-func (c *Client) DatabasePITRRestore(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error) {
-	var res databasePITRRestoreRes
+func (c *Client) DatabaseRestorePITR(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error) {
+	var res databaseRestorePITRRes
 	req := &httpclient.APIRequest{
 		Method:   http.MethodPost,
 		Endpoint: "/" + databasesResource + "/" + addonID + "/pitr/restore",
 		Expected: httpclient.Statuses{http.StatusCreated},
-		Params:   databasePITRRestorePayload{RestoreTime: restoreTime},
+		Params:   databaseRestorePITRPayload{RestoreTime: restoreTime},
 	}
 	err := c.DBAPI(app, addonID).DoRequest(ctx, req, &res)
 	if err != nil {

--- a/vendor/github.com/Scalingo/go-scalingo/v11/mocks_sig.json
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/mocks_sig.json
@@ -10,7 +10,7 @@
   "..ContainerSizesService": "e2 db 25 a1 01 52 dc e9 6f 7b f4 59 68 95 86 b9 5e 39 8a 61",
   "..ContainersService": "ef 14 ae 81 c9 b4 6a 13 48 e8 bf 44 7d b5 b2 a6 4d e5 02 11",
   "..CronTasksService": "9b d9 a3 ca 9f 9a f7 73 cb b1 aa 80 df 90 21 ff 14 92 b4 4d",
-  "..DatabasesService": "7c 84 0b 87 60 d6 b9 c7 3a a9 53 d2 3a 1c b4 e4 46 f1 83 28",
+  "..DatabasesService": "5c 64 37 ad 77 42 06 c3 93 dd ae 69 b9 42 2a a3 73 e6 bd ba",
   "..DeploymentsService": "e1 c5 95 e5 0e 4d db 1e ec 9a 83 d8 e5 41 cc 24 ce f6 ea ba",
   "..DomainsService": "b5 19 0f 10 5b f2 48 74 c6 c2 7b 27 7d 3b b8 ff 10 80 b3 6f",
   "..EventsService": "13 7a 12 83 bf 3f 84 49 dc db 64 c3 d5 e8 4a c0 08 8c 78 f6",

--- a/vendor/github.com/Scalingo/go-scalingo/v11/mocks_sig.json
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/mocks_sig.json
@@ -10,7 +10,7 @@
   "..ContainerSizesService": "e2 db 25 a1 01 52 dc e9 6f 7b f4 59 68 95 86 b9 5e 39 8a 61",
   "..ContainersService": "ef 14 ae 81 c9 b4 6a 13 48 e8 bf 44 7d b5 b2 a6 4d e5 02 11",
   "..CronTasksService": "9b d9 a3 ca 9f 9a f7 73 cb b1 aa 80 df 90 21 ff 14 92 b4 4d",
-  "..DatabasesService": "5c 64 37 ad 77 42 06 c3 93 dd ae 69 b9 42 2a a3 73 e6 bd ba",
+  "..DatabasesService": "18 b5 24 09 4c 3b 72 3b ea b9 fb b3 2a d3 5c fb 64 d3 c3 7a",
   "..DeploymentsService": "e1 c5 95 e5 0e 4d db 1e ec 9a 83 d8 e5 41 cc 24 ce f6 ea ba",
   "..DomainsService": "b5 19 0f 10 5b f2 48 74 c6 c2 7b 27 7d 3b b8 ff 10 80 b3 6f",
   "..EventsService": "13 7a 12 83 bf 3f 84 49 dc db 64 c3 d5 e8 4a c0 08 8c 78 f6",

--- a/vendor/github.com/Scalingo/go-scalingo/v11/scalingomock/api_mock.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/scalingomock/api_mock.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	io "io"
 	reflect "reflect"
+	time "time"
 
 	scalingo "github.com/Scalingo/go-scalingo/v11"
 	http "github.com/Scalingo/go-scalingo/v11/http"
@@ -752,6 +753,21 @@ func (m *MockAPI) DatabaseListMaintenance(ctx context.Context, app, addonID stri
 func (mr *MockAPIMockRecorder) DatabaseListMaintenance(ctx, app, addonID, paginationReq any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseListMaintenance", reflect.TypeOf((*MockAPI)(nil).DatabaseListMaintenance), ctx, app, addonID, paginationReq)
+}
+
+// DatabasePITRRestore mocks base method.
+func (m *MockAPI) DatabasePITRRestore(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DatabasePITRRestore", ctx, app, addonID, restoreTime)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DatabasePITRRestore indicates an expected call of DatabasePITRRestore.
+func (mr *MockAPIMockRecorder) DatabasePITRRestore(ctx, app, addonID, restoreTime any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabasePITRRestore", reflect.TypeOf((*MockAPI)(nil).DatabasePITRRestore), ctx, app, addonID, restoreTime)
 }
 
 // DatabaseShow mocks base method.

--- a/vendor/github.com/Scalingo/go-scalingo/v11/scalingomock/api_mock.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/scalingomock/api_mock.go
@@ -755,19 +755,19 @@ func (mr *MockAPIMockRecorder) DatabaseListMaintenance(ctx, app, addonID, pagina
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseListMaintenance", reflect.TypeOf((*MockAPI)(nil).DatabaseListMaintenance), ctx, app, addonID, paginationReq)
 }
 
-// DatabasePITRRestore mocks base method.
-func (m *MockAPI) DatabasePITRRestore(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error) {
+// DatabaseRestorePITR mocks base method.
+func (m *MockAPI) DatabaseRestorePITR(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DatabasePITRRestore", ctx, app, addonID, restoreTime)
+	ret := m.ctrl.Call(m, "DatabaseRestorePITR", ctx, app, addonID, restoreTime)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DatabasePITRRestore indicates an expected call of DatabasePITRRestore.
-func (mr *MockAPIMockRecorder) DatabasePITRRestore(ctx, app, addonID, restoreTime any) *gomock.Call {
+// DatabaseRestorePITR indicates an expected call of DatabaseRestorePITR.
+func (mr *MockAPIMockRecorder) DatabaseRestorePITR(ctx, app, addonID, restoreTime any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabasePITRRestore", reflect.TypeOf((*MockAPI)(nil).DatabasePITRRestore), ctx, app, addonID, restoreTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseRestorePITR", reflect.TypeOf((*MockAPI)(nil).DatabaseRestorePITR), ctx, app, addonID, restoreTime)
 }
 
 // DatabaseShow mocks base method.

--- a/vendor/github.com/Scalingo/go-scalingo/v11/scalingomock/databasesservice_mock.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/scalingomock/databasesservice_mock.go
@@ -84,19 +84,19 @@ func (mr *MockDatabasesServiceMockRecorder) DatabaseListMaintenance(ctx, app, ad
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseListMaintenance", reflect.TypeOf((*MockDatabasesService)(nil).DatabaseListMaintenance), ctx, app, addonID, paginationReq)
 }
 
-// DatabasePITRRestore mocks base method.
-func (m *MockDatabasesService) DatabasePITRRestore(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error) {
+// DatabaseRestorePITR mocks base method.
+func (m *MockDatabasesService) DatabaseRestorePITR(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DatabasePITRRestore", ctx, app, addonID, restoreTime)
+	ret := m.ctrl.Call(m, "DatabaseRestorePITR", ctx, app, addonID, restoreTime)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// DatabasePITRRestore indicates an expected call of DatabasePITRRestore.
-func (mr *MockDatabasesServiceMockRecorder) DatabasePITRRestore(ctx, app, addonID, restoreTime any) *gomock.Call {
+// DatabaseRestorePITR indicates an expected call of DatabaseRestorePITR.
+func (mr *MockDatabasesServiceMockRecorder) DatabaseRestorePITR(ctx, app, addonID, restoreTime any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabasePITRRestore", reflect.TypeOf((*MockDatabasesService)(nil).DatabasePITRRestore), ctx, app, addonID, restoreTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseRestorePITR", reflect.TypeOf((*MockDatabasesService)(nil).DatabaseRestorePITR), ctx, app, addonID, restoreTime)
 }
 
 // DatabaseShow mocks base method.

--- a/vendor/github.com/Scalingo/go-scalingo/v11/scalingomock/databasesservice_mock.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/scalingomock/databasesservice_mock.go
@@ -7,6 +7,7 @@ package scalingomock
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	scalingo "github.com/Scalingo/go-scalingo/v11"
 	pagination "github.com/Scalingo/go-utils/pagination"
@@ -81,6 +82,21 @@ func (m *MockDatabasesService) DatabaseListMaintenance(ctx context.Context, app,
 func (mr *MockDatabasesServiceMockRecorder) DatabaseListMaintenance(ctx, app, addonID, paginationReq any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseListMaintenance", reflect.TypeOf((*MockDatabasesService)(nil).DatabaseListMaintenance), ctx, app, addonID, paginationReq)
+}
+
+// DatabasePITRRestore mocks base method.
+func (m *MockDatabasesService) DatabasePITRRestore(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DatabasePITRRestore", ctx, app, addonID, restoreTime)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DatabasePITRRestore indicates an expected call of DatabasePITRRestore.
+func (mr *MockDatabasesServiceMockRecorder) DatabasePITRRestore(ctx, app, addonID, restoreTime any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabasePITRRestore", reflect.TypeOf((*MockDatabasesService)(nil).DatabasePITRRestore), ctx, app, addonID, restoreTime)
 }
 
 // DatabaseShow mocks base method.

--- a/vendor/github.com/Scalingo/go-scalingo/v11/version.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/version.go
@@ -1,3 +1,3 @@
 package scalingo
 
-var Version = "11.1.1"
+var Version = "11.2.0"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -37,7 +37,7 @@ github.com/ProtonMail/go-crypto/openpgp/packet
 github.com/ProtonMail/go-crypto/openpgp/s2k
 github.com/ProtonMail/go-crypto/openpgp/x25519
 github.com/ProtonMail/go-crypto/openpgp/x448
-# github.com/Scalingo/go-scalingo/v11 v11.1.1
+# github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260804160306-6c1691e7ad1f
 ## explicit; go 1.25.0
 github.com/Scalingo/go-scalingo/v11
 github.com/Scalingo/go-scalingo/v11/billing

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -37,7 +37,7 @@ github.com/ProtonMail/go-crypto/openpgp/packet
 github.com/ProtonMail/go-crypto/openpgp/s2k
 github.com/ProtonMail/go-crypto/openpgp/x25519
 github.com/ProtonMail/go-crypto/openpgp/x448
-# github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260804160306-6c1691e7ad1f
+# github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260806084722-668209583641
 ## explicit; go 1.25.0
 github.com/Scalingo/go-scalingo/v11
 github.com/Scalingo/go-scalingo/v11/billing

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -37,7 +37,7 @@ github.com/ProtonMail/go-crypto/openpgp/packet
 github.com/ProtonMail/go-crypto/openpgp/s2k
 github.com/ProtonMail/go-crypto/openpgp/x25519
 github.com/ProtonMail/go-crypto/openpgp/x448
-# github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260806084722-668209583641
+# github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260810154739-f30bd2e7ef2c
 ## explicit; go 1.25.0
 github.com/Scalingo/go-scalingo/v11
 github.com/Scalingo/go-scalingo/v11/billing

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -37,7 +37,7 @@ github.com/ProtonMail/go-crypto/openpgp/packet
 github.com/ProtonMail/go-crypto/openpgp/s2k
 github.com/ProtonMail/go-crypto/openpgp/x25519
 github.com/ProtonMail/go-crypto/openpgp/x448
-# github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260810154739-f30bd2e7ef2c
+# github.com/Scalingo/go-scalingo/v11 v11.2.0
 ## explicit; go 1.25.0
 github.com/Scalingo/go-scalingo/v11
 github.com/Scalingo/go-scalingo/v11/billing


### PR DESCRIPTION
Add a new command to restore PITR.
It reuses the same mechanism as maintenance. Both components are shared between SR addons and DR databases.
It adds a small check to ensure the time is correctly parsed.

- [X] Add a changelog entry in the section "To Be Released" of CHANGELOG.md
- [x] right now depending on this [PR](https://github.com/Scalingo/go-scalingo/pull/512). Before merging it should be set to a released version (or not?)
- [X] QA not executed yet
  - Working as expected, restoration is triggered