### PR TITLE
task(deps): update go-scalingo to remove support for the db-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* task(deps): update go-scalingo to remove support for the db-api
+
 ## v1.47.0
 
 * chore(deps/go-scalingo): update go-scalingo to add support of continuousbackup events

--- a/addons/config.go
+++ b/addons/config.go
@@ -43,7 +43,7 @@ func UpdateConfig(ctx context.Context, app, addon string, options UpdateAddonCon
 
 	// fetching the current database maintenance window allows
 	// to only overload the specified options
-	db, err := c.DatabaseShow(ctx, app, addon)
+	db, err := c.DatabaseShow(ctx, addon)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "get database information")
 	}
@@ -72,7 +72,7 @@ func UpdateConfig(ctx context.Context, app, addon string, options UpdateAddonCon
 
 	weekdayUTC, startingHourUTC := utils.ConvertDayAndHourToTimezone(weekdayLocal, startingHourLocal, time.Local, time.UTC)
 
-	_, err = c.DatabaseUpdateMaintenanceWindow(ctx, app, addon, scalingo.MaintenanceWindowParams{
+	_, err = c.DatabaseUpdateMaintenanceWindow(ctx, addon, scalingo.MaintenanceWindowParams{
 		WeekdayUTC:      utils.IntPtr(int(weekdayUTC)),
 		StartingHourUTC: utils.IntPtr(startingHourUTC),
 	})

--- a/addons/info.go
+++ b/addons/info.go
@@ -58,7 +58,7 @@ func Info(ctx context.Context, app, addon string) error {
 }
 
 func getDatabaseInfo(ctx context.Context, c *scalingo.Client, app, addon string) ([][]string, error) {
-	dbInfo, err := c.DatabaseShow(ctx, app, addon)
+	dbInfo, err := c.DatabaseShow(ctx, addon)
 	if err != nil {
 		return [][]string{}, errors.Wrap(ctx, err, "get database information")
 	}

--- a/cmd/backups.go
+++ b/cmd/backups.go
@@ -27,7 +27,7 @@ var (
 			currentApp := detect.CurrentApp(ctx, c)
 			addonName := addonUUIDFromFlags(ctx, c, currentApp, true)
 
-			err := db.ListBackups(ctx, currentApp, addonName)
+			err := db.ListBackups(ctx, addonName)
 			if err != nil {
 				errorQuit(ctx, err)
 			}

--- a/cmd/databases.go
+++ b/cmd/databases.go
@@ -46,7 +46,7 @@ var (
 				errorQuit(ctx, errors.New(ctx, "feature argument should be specified"))
 			}
 			feature := c.Args().First()
-			err := db.EnableFeature(ctx, c, currentResource, addonName, feature)
+			err := db.EnableFeature(ctx, c, addonName, feature)
 			if err != nil {
 				errorQuit(ctx, err)
 			}
@@ -77,7 +77,7 @@ var (
 				errorQuit(ctx, errors.New(ctx, "feature argument should be specified"))
 			}
 			feature := c.Args().First()
-			err := db.DisableFeature(ctx, currentResource, addonName, feature)
+			err := db.DisableFeature(ctx, addonName, feature)
 			if err != nil {
 				errorQuit(ctx, err)
 			}
@@ -140,7 +140,7 @@ var (
 			}
 
 			if disable || scheduleAtFlag != "" {
-				err := db.BackupsConfiguration(ctx, currentResource, addonName, params)
+				err := db.BackupsConfiguration(ctx, addonName, params)
 				if err != nil {
 					errorQuit(ctx, err)
 				}

--- a/cmd/firewall_rules.go
+++ b/cmd/firewall_rules.go
@@ -41,7 +41,7 @@ var (
 
 			utils.CheckForConsent(ctx, databaseName, utils.ConsentTypeDBs)
 
-			err = dbng.FirewallRulesList(ctx, databaseName, addonID)
+			err = dbng.FirewallRulesList(ctx, addonID)
 			if err != nil {
 				errorQuit(ctx, err)
 			}
@@ -193,32 +193,18 @@ var (
 	}
 
 	databaseFirewallManagedRangesCommand = cli.Command{
-		Name:      "database-firewall-managed-ranges",
-		Category:  "Databases DR",
-		Usage:     "List available managed ranges for a database",
-		ArgsUsage: "database-id",
-		Flags:     []cli.Flag{databaseFlag()},
+		Name:     "database-firewall-managed-ranges",
+		Category: "Databases DR",
+		Usage:    "List available managed ranges",
 		Description: CommandDescription{
-			Description: "List all available managed ranges for firewall rules of a database",
+			Description: "List all available managed ranges for firewall rules",
 			Examples: []string{
-				"scalingo database-firewall-managed-ranges my-db-id",
-				"scalingo --database my-db database-firewall-managed-ranges",
+				"scalingo database-firewall-managed-ranges",
 			},
 			SeeAlso: []string{"database-firewall-rules", "database-firewall-rules-add", "database-firewall-rules-remove"},
 		}.Render(),
 		Action: func(ctx context.Context, c *cli.Command) error {
-			databaseName, addonID, err := detect.GetDatabaseFromArgs(ctx, c)
-			if errors.Is(err, detect.ErrTooManyArguments) {
-				io.Error(err)
-				return cli.ShowCommandHelp(ctx, c, "database-firewall-managed-ranges")
-			}
-			if err != nil {
-				errorQuit(ctx, err)
-			}
-
-			utils.CheckForConsent(ctx, databaseName, utils.ConsentTypeDBs)
-
-			err = dbng.FirewallManagedRangesList(ctx, databaseName, addonID)
+			err := dbng.FirewallManagedRangesList(ctx)
 			if err != nil {
 				errorQuit(ctx, err)
 			}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -52,7 +52,7 @@ var (
 			} else {
 				utils.CheckForConsent(ctx, currentResource, utils.ConsentTypeDBs)
 
-				err = db.Logs(ctx, currentResource, addonID, db.LogsOpts{
+				err = db.Logs(ctx, addonID, db.LogsOpts{
 					Follow: c.Bool("f"),
 					Count:  c.Int("n"),
 				})

--- a/cmd/logs_archives.go
+++ b/cmd/logs_archives.go
@@ -46,7 +46,7 @@ var (
 			} else {
 				utils.CheckForConsent(ctx, currentResource, utils.ConsentTypeDBs)
 
-				err = db.LogsArchives(ctx, currentResource, addonID, c.Int("p"))
+				err = db.LogsArchives(ctx, addonID, c.Int("p"))
 			}
 
 			if err != nil {

--- a/cmd/maintenance.go
+++ b/cmd/maintenance.go
@@ -38,7 +38,7 @@ var databaseMaintenanceList = cli.Command{
 			addonName = addonUUIDFromFlags(ctx, c, currentResource, true)
 		}
 
-		err := maintenance.List(ctx, currentResource, addonName, pagination.NewRequest(c.Int("page"), c.Int("per-page")))
+		err := maintenance.List(ctx, addonName, pagination.NewRequest(c.Int("page"), c.Int("per-page")))
 		if err != nil {
 			errorQuit(ctx, err)
 		}
@@ -78,7 +78,7 @@ var databaseMaintenanceInfo = cli.Command{
 		}
 		maintenanceID := c.Args().First()
 
-		err := maintenance.Info(ctx, currentResource, addonName, maintenanceID)
+		err := maintenance.Info(ctx, addonName, maintenanceID)
 		if err != nil {
 			errorQuit(ctx, err)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -35,7 +35,6 @@ type Config struct {
 	// Override region configuration
 	ScalingoAPIURL  string `envconfig:"SCALINGO_API_URL"`
 	ScalingoAuthURL string `envconfig:"SCALINGO_AUTH_URL"`
-	ScalingoDbURL   string `envconfig:"SCALINGO_DB_URL"`
 	ScalingoRegion  string `envconfig:"SCALINGO_REGION"`
 	ScalingoSSHHost string `envconfig:"SCALINGO_SSH_HOST"`
 
@@ -59,7 +58,6 @@ var (
 	env = map[string]string{
 		"SCALINGO_AUTH_URL":  "https://auth.scalingo.com",
 		"SCALINGO_API_URL":   "",
-		"SCALINGO_DB_URL":    "",
 		"SCALINGO_SSH_HOST":  "",
 		"SCALINGO_REGION":    "",
 		"API_VERSION":        "1",
@@ -165,9 +163,8 @@ func (config Config) scalingoClientBaseConfig(opts ClientConfigOpts) scalingo.Cl
 func (config Config) scalingoClientConfig(ctx context.Context, opts ClientConfigOpts) (scalingo.ClientConfig, error) {
 	c := config.scalingoClientBaseConfig(opts)
 	if !opts.AuthOnly {
-		if config.ScalingoAPIURL != "" && config.ScalingoDbURL != "" {
+		if config.ScalingoAPIURL != "" {
 			c.APIEndpoint = config.ScalingoAPIURL
-			c.DatabaseAPIEndpoint = config.ScalingoDbURL
 		} else {
 			region, err := GetRegion(ctx, config, config.ScalingoRegion, GetRegionOpts{
 				Token: opts.APIToken,
@@ -176,7 +173,6 @@ func (config Config) scalingoClientConfig(ctx context.Context, opts ClientConfig
 				return c, errors.Wrapf(ctx, err, "fail to get region '%v' specifications", config.ScalingoRegion)
 			}
 			c.APIEndpoint = region.API
-			c.DatabaseAPIEndpoint = region.DatabaseAPI
 		}
 	}
 	return c, nil

--- a/db/backup_create.go
+++ b/db/backup_create.go
@@ -23,7 +23,7 @@ func CreateBackup(ctx context.Context, app, addon string) error {
 	if err != nil {
 		return errors.Wrapf(ctx, err, "fail to get Scalingo client")
 	}
-	backup, err := client.BackupCreate(ctx, app, addon)
+	backup, err := client.BackupCreate(ctx, addon)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "create backup for addon %s on app %s", addon, app)
 	}
@@ -40,7 +40,7 @@ func CreateBackup(ctx context.Context, app, addon string) error {
 
 		time.Sleep(1 * time.Second)
 
-		backup, err = client.BackupShow(ctx, app, addon, backup.ID)
+		backup, err = client.BackupShow(ctx, backup.ID)
 		if err != nil {
 			return errors.Wrapf(ctx, err, "fail to refresh backup state")
 		}

--- a/db/backup_download.go
+++ b/db/backup_download.go
@@ -62,7 +62,7 @@ func DownloadBackup(ctx context.Context, app, addonID, backupID string, opts Dow
 	}
 
 	if backupID == "" {
-		backups, err := client.BackupList(ctx, app, addonID)
+		backups, err := client.BackupList(ctx, addonID)
 		if err != nil {
 			return errors.Wrap(ctx, err, "list backups")
 		}
@@ -83,7 +83,7 @@ func DownloadBackup(ctx context.Context, app, addonID, backupID string, opts Dow
 	spinner.Start()
 
 	// Get backup metadatas
-	backup, err := client.BackupShow(ctx, app, addonID, backupID)
+	backup, err := client.BackupShow(ctx, backupID)
 	if err != nil {
 		return errors.Wrap(ctx, err, "get backup")
 	}
@@ -108,7 +108,7 @@ func DownloadBackup(ctx context.Context, app, addonID, backupID string, opts Dow
 	}
 
 	// Get the pre-signed download URL
-	downloadURL, err := client.BackupDownloadURL(ctx, app, addonID, backupID)
+	downloadURL, err := client.BackupDownloadURL(ctx, addonID, backupID)
 	if err != nil {
 		return errors.Wrap(ctx, err, "get backup download URL")
 	}

--- a/db/backups.go
+++ b/db/backups.go
@@ -14,12 +14,12 @@ import (
 	"github.com/Scalingo/go-utils/errors/v3"
 )
 
-func ListBackups(ctx context.Context, app, addon string) error {
+func ListBackups(ctx context.Context, addon string) error {
 	client, err := config.ScalingoClient(ctx)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "fail to get Scalingo client")
 	}
-	backups, err := client.BackupList(ctx, app, addon)
+	backups, err := client.BackupList(ctx, addon)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "fail to list backups")
 	}

--- a/db/backups_config.go
+++ b/db/backups_config.go
@@ -13,13 +13,13 @@ import (
 	"github.com/Scalingo/go-utils/errors/v3"
 )
 
-func BackupsConfiguration(ctx context.Context, app, addon string, params scalingo.DatabaseUpdatePeriodicBackupsConfigParams) error {
+func BackupsConfiguration(ctx context.Context, addon string, params scalingo.DatabaseUpdatePeriodicBackupsConfigParams) error {
 	client, err := config.ScalingoClient(ctx)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "fail to get Scalingo client")
 	}
 
-	db, err := client.DatabaseShow(ctx, app, addon)
+	db, err := client.DatabaseShow(ctx, addon)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "fail to get database current configuration")
 	}
@@ -31,7 +31,7 @@ func BackupsConfiguration(ctx context.Context, app, addon string, params scaling
 		return errors.New(ctx, msg)
 	}
 
-	db, err = client.DatabaseUpdatePeriodicBackupsConfig(ctx, app, addon, params)
+	db, err = client.DatabaseUpdatePeriodicBackupsConfig(ctx, addon, params)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "fail to configure the periodic backups")
 	}

--- a/db/features.go
+++ b/db/features.go
@@ -15,7 +15,7 @@ import (
 
 // EnableFeature is the command handler to enable a database feature on a given
 // database addon, like 'force-ssl' or 'public-availability'
-func EnableFeature(ctx context.Context, c *cli.Command, app, addon, feature string) error {
+func EnableFeature(ctx context.Context, c *cli.Command, addon, feature string) error {
 	spinner := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 	spinner.Suffix = " Enabling database feature"
 	spinner.Start()
@@ -26,7 +26,7 @@ func EnableFeature(ctx context.Context, c *cli.Command, app, addon, feature stri
 		return errors.Wrapf(ctx, err, "fail to get Scalingo client")
 	}
 
-	res, err := client.DatabaseEnableFeature(ctx, app, addon, feature)
+	res, err := client.DatabaseEnableFeature(ctx, addon, feature)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "fail to enable feature '%v'", feature)
 	}
@@ -45,7 +45,7 @@ func EnableFeature(ctx context.Context, c *cli.Command, app, addon, feature stri
 
 	if res.Status == scalingo.DatabaseFeatureStatusPending && c.Bool("synchronous") {
 		io.Infof("Waiting for operation completion...")
-		err = waitFeatureUntilActivated(ctx, client, app, addon, feature)
+		err = waitFeatureUntilActivated(ctx, client, addon, feature)
 		if err != nil {
 			return errors.Wrapf(ctx, err, "fail to wait for feature '%v' to be enabled", feature)
 		}
@@ -54,11 +54,11 @@ func EnableFeature(ctx context.Context, c *cli.Command, app, addon, feature stri
 	return nil
 }
 
-func waitFeatureUntilActivated(ctx context.Context, client *scalingo.Client, app, addon, feature string) error {
+func waitFeatureUntilActivated(ctx context.Context, client *scalingo.Client, addon, feature string) error {
 	ticker := time.NewTicker(3 * time.Second)
 	defer ticker.Stop()
 	for range ticker.C {
-		db, err := client.DatabaseShow(ctx, app, addon)
+		db, err := client.DatabaseShow(ctx, addon)
 		if err != nil {
 			return errors.Wrapf(ctx, err, "fail to refresh database metadata")
 		}
@@ -80,7 +80,7 @@ func waitFeatureUntilActivated(ctx context.Context, client *scalingo.Client, app
 
 // DisableFeature is the command handler to disable a database feature on a
 // database addon like 'force-ssl' or 'public-availability'
-func DisableFeature(ctx context.Context, app, addon, feature string) error {
+func DisableFeature(ctx context.Context, addon, feature string) error {
 	spinner := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 	spinner.Suffix = " Disabling database feature"
 	spinner.Start()
@@ -91,7 +91,7 @@ func DisableFeature(ctx context.Context, app, addon, feature string) error {
 		return errors.Wrapf(ctx, err, "fail to get Scalingo client")
 	}
 
-	_, err = client.DatabaseDisableFeature(ctx, app, addon, feature)
+	_, err = client.DatabaseDisableFeature(ctx, addon, feature)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "fail to disable feature '%v'", feature)
 	}

--- a/db/logs.go
+++ b/db/logs.go
@@ -16,13 +16,13 @@ type LogsOpts struct {
 // Logs displays the addon logs.
 // app may be an app UUID or name.
 // addon may be a addon UUID or an addon type (e.g. MongoDB).
-func Logs(ctx context.Context, app, addonUUID string, opts LogsOpts) error {
+func Logs(ctx context.Context, addonUUID string, opts LogsOpts) error {
 	c, err := config.ScalingoClient(ctx)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "fail to get Scalingo client")
 	}
 
-	url, err := c.AddonLogsURL(ctx, app, addonUUID)
+	url, err := c.AddonLogsURL(ctx, addonUUID)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "fail to get log URL")
 	}

--- a/db/logs_archive.go
+++ b/db/logs_archive.go
@@ -11,7 +11,7 @@ import (
 	"github.com/Scalingo/go-utils/errors/v3"
 )
 
-func LogsArchives(ctx context.Context, app, addon string, page int) error {
+func LogsArchives(ctx context.Context, addon string, page int) error {
 	if page < 0 {
 		return errors.New(ctx, "Page must be greather than 0.")
 	}
@@ -24,7 +24,7 @@ func LogsArchives(ctx context.Context, app, addon string, page int) error {
 		return errors.Wrapf(ctx, err, "fail to get Scalingo client")
 	}
 
-	logsRes, err := c.AddonLogsArchives(ctx, app, addon, page)
+	logsRes, err := c.AddonLogsArchives(ctx, addon, page)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "fail to get addon logs archives")
 	}

--- a/db/maintenance/info.go
+++ b/db/maintenance/info.go
@@ -15,13 +15,13 @@ import (
 	"github.com/Scalingo/go-utils/errors/v3"
 )
 
-func Info(ctx context.Context, app, addonUUID, maintenanceID string) error {
+func Info(ctx context.Context, addonUUID, maintenanceID string) error {
 	c, err := config.ScalingoClient(ctx)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "get Scalingo client")
 	}
 
-	maintenanceInfo, err := c.DatabaseShowMaintenance(ctx, app, addonUUID, maintenanceID)
+	maintenanceInfo, err := c.DatabaseShowMaintenance(ctx, addonUUID, maintenanceID)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "get the maintenance")
 	}
@@ -32,7 +32,7 @@ func Info(ctx context.Context, app, addonUUID, maintenanceID string) error {
 	if maintenanceInfo.StartedAt != nil {
 		startedAtMessage = maintenanceInfo.StartedAt.Local().Format(utils.TimeFormat)
 	} else {
-		database, err := c.DatabaseShow(ctx, app, addonUUID)
+		database, err := c.DatabaseShow(ctx, addonUUID)
 		if err != nil {
 			return errors.Wrapf(ctx, err, "get database information")
 		}

--- a/db/maintenance/list.go
+++ b/db/maintenance/list.go
@@ -14,13 +14,13 @@ import (
 	"github.com/Scalingo/go-utils/pagination"
 )
 
-func List(ctx context.Context, app string, addonName string, paginationReq pagination.Request) error {
+func List(ctx context.Context, addonName string, paginationReq pagination.Request) error {
 	c, err := config.ScalingoClient(ctx)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "get Scalingo client")
 	}
 
-	maintenances, pagination, err := c.DatabaseListMaintenance(ctx, app, addonName, paginationReq)
+	maintenances, pagination, err := c.DatabaseListMaintenance(ctx, addonName, paginationReq)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "list the database maintenance")
 	}

--- a/db/users/create.go
+++ b/db/users/create.go
@@ -31,7 +31,7 @@ func CreateUser(ctx context.Context, app, addonUUID, username string, readonly b
 	if err != nil {
 		return errors.Wrap(ctx, err, "get Scalingo client")
 	}
-	l, err := c.DatabaseListUsers(ctx, app, addonUUID)
+	l, err := c.DatabaseListUsers(ctx, addonUUID)
 	if err != nil {
 		return errors.Wrap(ctx, err, "list the database's users")
 	}
@@ -68,7 +68,7 @@ func CreateUser(ctx context.Context, app, addonUUID, username string, readonly b
 		PasswordConfirmation: confirmedPassword,
 		ReadOnly:             readonly,
 	}
-	databaseUsers, err := c.DatabaseCreateUser(ctx, app, addonUUID, user)
+	databaseUsers, err := c.DatabaseCreateUser(ctx, addonUUID, user)
 	if err != nil {
 		return errors.Wrap(ctx, err, "create the given database user")
 	}

--- a/db/users/delete.go
+++ b/db/users/delete.go
@@ -26,7 +26,7 @@ func DeleteUser(ctx context.Context, app, addonUUID, username string) error {
 		return errors.Wrap(ctx, err, "get Scalingo client")
 	}
 
-	databaseUsers, err := c.DatabaseListUsers(ctx, app, addonUUID)
+	databaseUsers, err := c.DatabaseListUsers(ctx, addonUUID)
 	if err != nil {
 		return errors.Wrap(ctx, err, "list the database's users")
 	}
@@ -48,7 +48,7 @@ func DeleteUser(ctx context.Context, app, addonUUID, username string) error {
 		return nil
 	}
 
-	err = c.DatabaseDeleteUser(ctx, app, addonUUID, username)
+	err = c.DatabaseDeleteUser(ctx, addonUUID, username)
 	if err != nil {
 		return errors.Wrapf(ctx, err, "delete given user from database %v", username)
 	}

--- a/db/users/list.go
+++ b/db/users/list.go
@@ -28,7 +28,7 @@ func List(ctx context.Context, app, addonUUID string) error {
 		return errors.Wrap(ctx, err, "get Scalingo client")
 	}
 
-	databaseUsers, err := c.DatabaseListUsers(ctx, app, addonUUID)
+	databaseUsers, err := c.DatabaseListUsers(ctx, addonUUID)
 	if err != nil {
 		return errors.Wrap(ctx, err, "list the database's users")
 	}

--- a/db/users/update_password.go
+++ b/db/users/update_password.go
@@ -31,7 +31,7 @@ func UpdateUserPassword(ctx context.Context, app, addonUUID, username string) er
 		return errors.Wrap(ctx, err, "get Scalingo client")
 	}
 
-	l, err := c.DatabaseListUsers(ctx, app, addonUUID)
+	l, err := c.DatabaseListUsers(ctx, addonUUID)
 	if err != nil {
 		return errors.Wrap(ctx, err, "list the database's users")
 	}
@@ -67,7 +67,7 @@ func UpdateUserPassword(ctx context.Context, app, addonUUID, username string) er
 			Password:             password,
 			PasswordConfirmation: confirmedPassword,
 		}
-		databaseUser, err = c.DatabaseUpdateUser(ctx, app, addonUUID, username, userUpdateParam)
+		databaseUser, err = c.DatabaseUpdateUser(ctx, addonUUID, username, userUpdateParam)
 		if err != nil {
 			return errors.Wrap(ctx, err, "update password of the given database user")
 		}

--- a/dbng/firewall_rules.go
+++ b/dbng/firewall_rules.go
@@ -12,13 +12,13 @@ import (
 	"github.com/Scalingo/go-utils/errors/v3"
 )
 
-func FirewallRulesList(ctx context.Context, databaseID, addonID string) error {
+func FirewallRulesList(ctx context.Context, addonID string) error {
 	c, err := config.ScalingoClient(ctx)
 	if err != nil {
 		return errors.Wrap(ctx, err, "get Scalingo client")
 	}
 
-	rules, err := c.Preview().FirewallRulesList(ctx, databaseID, addonID)
+	rules, err := c.Preview().FirewallRulesList(ctx, addonID)
 	if err != nil {
 		return errors.Wrap(ctx, err, "list firewall rules")
 	}
@@ -55,7 +55,7 @@ func FirewallRulesAdd(ctx context.Context, databaseID, addonID string, params sc
 		return errors.Wrap(ctx, err, "get Scalingo client")
 	}
 
-	rule, err := c.Preview().FirewallRulesCreate(ctx, databaseID, addonID, params)
+	rule, err := c.Preview().FirewallRulesCreate(ctx, addonID, params)
 	if err != nil {
 		return errors.Wrap(ctx, err, "add firewall rule")
 	}
@@ -72,7 +72,7 @@ func FirewallRulesRemove(ctx context.Context, databaseID, addonID, ruleID string
 		return errors.Wrap(ctx, err, "get Scalingo client")
 	}
 
-	err = c.Preview().FirewallRulesDestroy(ctx, databaseID, addonID, ruleID)
+	err = c.Preview().FirewallRulesDestroy(ctx, addonID, ruleID)
 	if err != nil {
 		return errors.Wrap(ctx, err, "remove firewall rule")
 	}
@@ -83,13 +83,13 @@ func FirewallRulesRemove(ctx context.Context, databaseID, addonID, ruleID string
 	return nil
 }
 
-func FirewallManagedRangesList(ctx context.Context, databaseID, addonID string) error {
+func FirewallManagedRangesList(ctx context.Context) error {
 	c, err := config.ScalingoClient(ctx)
 	if err != nil {
 		return errors.Wrap(ctx, err, "get Scalingo client")
 	}
 
-	ranges, err := c.Preview().FirewallRulesGetManagedRanges(ctx, databaseID, addonID)
+	ranges, err := c.Preview().FirewallRulesGetManagedRanges(ctx)
 	if err != nil {
 		return errors.Wrap(ctx, err, "list managed ranges")
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
-	github.com/Scalingo/go-scalingo/v11 v11.1.1
+	github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260810110303-774d8583f620
 	github.com/Scalingo/go-utils/errors/v3 v3.2.1
 	github.com/Scalingo/go-utils/logger v1.12.2
 	github.com/Scalingo/go-utils/pagination v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63n
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/Scalingo/go-scalingo/v11 v11.1.1 h1:INyoLmn8mLZYIN1JVSmI9e0P9bnYsMeAIqC/ZByWUWI=
-github.com/Scalingo/go-scalingo/v11 v11.1.1/go.mod h1:lH/1yV+WQ+Vi5ByGYNJRcWQkHKLaq/vtqZaQavwi3ZA=
+github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260810110303-774d8583f620 h1:2FvAN0yhWjlIQ8Q27eIfKAu1D1XKeh6Omh5saGHbivw=
+github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260810110303-774d8583f620/go.mod h1:188AcoLrztIhk3BQPaYHKJesSYXxBwWQvKWQoewKww0=
 github.com/Scalingo/go-utils/errors/v3 v3.2.1 h1:2w3qUz6MxJa3aqx/biz2G3JquSKsFnfz/E7wrNf/LPc=
 github.com/Scalingo/go-utils/errors/v3 v3.2.1/go.mod h1:jVVNoOdYFjuNkR/BeEZWNWJVvu4jmyLY4udlsQQyBss=
 github.com/Scalingo/go-utils/logger v1.12.2 h1:9vm83/gqjCIy5t+OuNYjkVOUrJtdMy78XNIv8E+OCCU=

--- a/vendor/github.com/Scalingo/go-scalingo/v11/CHANGELOG.md
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## To Be Released
 
+* task(client): Remove the DB-API client (breaking change)
+* feat(databases): Add new method to restore PITR
+
 ## 11.1.1
 
 * feat(events): add database continuous backup events

--- a/vendor/github.com/Scalingo/go-scalingo/v11/addons.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/addons.go
@@ -16,8 +16,8 @@ type AddonsService interface {
 	AddonDestroy(ctx context.Context, app, addonID string) error
 	AddonUpgrade(ctx context.Context, app, addonID string, params AddonUpgradeParams) (AddonRes, error)
 	AddonToken(ctx context.Context, app, addonID string) (string, error)
-	AddonLogsURL(ctx context.Context, app, addonID string) (string, error)
-	AddonLogsArchives(ctx context.Context, app, addonID string, page int) (*LogsArchivesResponse, error)
+	AddonLogsURL(ctx context.Context, addonID string) (string, error)
+	AddonLogsArchives(ctx context.Context, addonID string, page int) (*LogsArchivesResponse, error)
 }
 
 var _ AddonsService = (*Client)(nil)
@@ -139,9 +139,9 @@ func (c *Client) AddonToken(ctx context.Context, app, addonID string) (string, e
 	return res.Addon.Token, nil
 }
 
-func (c *Client) AddonLogsURL(ctx context.Context, app, addonID string) (string, error) {
+func (c *Client) AddonLogsURL(ctx context.Context, addonID string) (string, error) {
 	var urlRes AddonLogsURLRes
-	err := c.DBAPI(app, addonID).DoRequest(ctx, &httpclient.APIRequest{
+	err := c.ScalingoAPI().DoRequest(ctx, &httpclient.APIRequest{
 		Endpoint: "/databases/" + addonID + "/logs",
 	}, &urlRes)
 	if err != nil {
@@ -151,9 +151,9 @@ func (c *Client) AddonLogsURL(ctx context.Context, app, addonID string) (string,
 	return urlRes.URL, nil
 }
 
-func (c *Client) AddonLogsArchives(ctx context.Context, app, addonID string, page int) (*LogsArchivesResponse, error) {
+func (c *Client) AddonLogsArchives(ctx context.Context, addonID string, page int) (*LogsArchivesResponse, error) {
 	var logsRes LogsArchivesResponse
-	err := c.DBAPI(app, addonID).DoRequest(ctx, &httpclient.APIRequest{
+	err := c.ScalingoAPI().DoRequest(ctx, &httpclient.APIRequest{
 		Endpoint: "/databases/" + addonID + "/logs_archives",
 		Params: map[string]string{
 			"page": strconv.FormatInt(int64(page), 10),

--- a/vendor/github.com/Scalingo/go-scalingo/v11/backups.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/backups.go
@@ -10,11 +10,13 @@ import (
 )
 
 type BackupsService interface {
-	BackupList(ctx context.Context, app, addonID string) ([]Backup, error)
-	BackupCreate(ctx context.Context, app, addonID string) (*Backup, error)
-	BackupShow(ctx context.Context, app, addonID, backupID string) (*Backup, error)
-	BackupDownloadURL(ctx context.Context, app, addonID, backupID string) (string, error)
+	BackupList(ctx context.Context, addonID string) ([]Backup, error)
+	BackupCreate(ctx context.Context, addonID string) (*Backup, error)
+	BackupShow(ctx context.Context, backupID string) (*Backup, error)
+	BackupDownloadURL(ctx context.Context, addonID, backupID string) (string, error)
 }
+
+var _ BackupsService = (*Client)(nil)
 
 type BackupStatus string
 
@@ -55,40 +57,40 @@ type DownloadURLRes struct {
 	DownloadURL string `json:"download_url"`
 }
 
-func (c *Client) BackupList(ctx context.Context, app string, addonID string) ([]Backup, error) {
+func (c *Client) BackupList(ctx context.Context, addonID string) ([]Backup, error) {
 	var backupRes BackupsRes
-	err := c.DBAPI(app, addonID).SubresourceList(ctx, databasesResource, addonID, backupsResource, nil, &backupRes)
+	err := c.ScalingoAPI().SubresourceList(ctx, databasesResource, addonID, backupsResource, nil, &backupRes)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, "get backup")
 	}
 	return backupRes.Backups, nil
 }
 
-func (c *Client) BackupCreate(ctx context.Context, app, addonID string) (*Backup, error) {
+func (c *Client) BackupCreate(ctx context.Context, addonID string) (*Backup, error) {
 	var backupRes BackupRes
-	err := c.DBAPI(app, addonID).SubresourceAdd(ctx, databasesResource, addonID, backupsResource, nil, &backupRes)
+	err := c.ScalingoAPI().SubresourceAdd(ctx, databasesResource, addonID, backupsResource, nil, &backupRes)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, "schedule a new backup")
 	}
 	return &backupRes.Backup, nil
 }
 
-func (c *Client) BackupShow(ctx context.Context, app, addonID, backup string) (*Backup, error) {
+func (c *Client) BackupShow(ctx context.Context, backup string) (*Backup, error) {
 	var backupRes BackupRes
-	err := c.DBAPI(app, addonID).ResourceGet(ctx, "backups", backup, nil, &backupRes)
+	err := c.ScalingoAPI().ResourceGet(ctx, "backups", backup, nil, &backupRes)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, "get backup")
 	}
 	return &backupRes.Backup, nil
 }
 
-func (c *Client) BackupDownloadURL(ctx context.Context, app, addonID, backupID string) (string, error) {
+func (c *Client) BackupDownloadURL(ctx context.Context, addonID, backupID string) (string, error) {
 	var downloadRes DownloadURLRes
 	req := &httpclient.APIRequest{
 		Method:   http.MethodGet,
 		Endpoint: "/databases/" + addonID + "/backups/" + backupID + "/archive",
 	}
-	err := c.DBAPI(app, addonID).DoRequest(ctx, req, &downloadRes)
+	err := c.ScalingoAPI().DoRequest(ctx, req, &downloadRes)
 	if err != nil {
 		return "", errors.Wrap(ctx, err, "get backup archive")
 	}

--- a/vendor/github.com/Scalingo/go-scalingo/v11/client.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/client.go
@@ -46,7 +46,6 @@ type API interface {
 
 	ScalingoAPI() httpclient.Client
 	AuthAPI() httpclient.Client
-	DBAPI(app, addon string) httpclient.Client
 }
 
 var _ API = (*Client)(nil)
@@ -95,8 +94,6 @@ type ClientConfig struct {
 	APIPrefix              string
 	AuthEndpoint           string
 	AuthPrefix             string
-	DatabaseAPIEndpoint    string
-	DatabaseAPIPrefix      string
 	APIToken               string
 	Region                 string
 	UserAgent              string
@@ -108,9 +105,8 @@ type ClientConfig struct {
 }
 
 type ExtraHeaders struct {
-	API         http.Header
-	DatabaseAPI http.Header
-	Auth        http.Header
+	API  http.Header
+	Auth http.Header
 }
 
 func New(ctx context.Context, cfg ClientConfig) (*Client, error) {
@@ -143,7 +139,6 @@ func New(ctx context.Context, cfg ClientConfig) (*Client, error) {
 	}
 
 	cfg.APIEndpoint = region.API
-	cfg.DatabaseAPIEndpoint = region.DatabaseAPI
 	return &Client{
 		config: cfg,
 	}, nil
@@ -181,26 +176,6 @@ func (c *Client) ScalingoAPI() httpclient.Client {
 	}
 
 	return client
-}
-
-func (c *Client) DBAPI(app, addon string) httpclient.Client {
-	if c.dbClient != nil {
-		return c.dbClient
-	}
-
-	prefix := "/api"
-	if c.config.DatabaseAPIPrefix != "" {
-		prefix = c.config.DatabaseAPIPrefix
-	}
-	return httpclient.NewClient(httpclient.ClientConfig{
-		UserAgent:      c.config.UserAgent,
-		Timeout:        c.config.Timeout,
-		TLSConfig:      c.config.TLSConfig,
-		APIConfig:      httpclient.APIConfig{Prefix: prefix},
-		TokenGenerator: httpclient.NewAddonTokenGenerator(app, addon, c),
-		Endpoint:       c.config.DatabaseAPIEndpoint,
-		ExtraHeaders:   c.config.ExtraHeaders.DatabaseAPI,
-	})
 }
 
 func (c *Client) AuthAPI() httpclient.Client {

--- a/vendor/github.com/Scalingo/go-scalingo/v11/database_type_versions.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/database_type_versions.go
@@ -40,9 +40,9 @@ type DatabaseTypeVersionShowResponse struct {
 	DatabaseTypeVersion DatabaseTypeVersion `json:"database_type_version"`
 }
 
-func (c Client) DatabaseTypeVersion(ctx context.Context, appID, addonID, versionID string) (DatabaseTypeVersion, error) {
+func (c Client) DatabaseTypeVersion(ctx context.Context, versionID string) (DatabaseTypeVersion, error) {
 	var res DatabaseTypeVersionShowResponse
-	err := c.DBAPI(appID, addonID).DoRequest(ctx, &httpclient.APIRequest{
+	err := c.ScalingoAPI().DoRequest(ctx, &httpclient.APIRequest{
 		Method:   http.MethodGet,
 		Endpoint: "/database_type_versions/" + versionID,
 		Expected: httpclient.Statuses{http.StatusOK},

--- a/vendor/github.com/Scalingo/go-scalingo/v11/databases.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/databases.go
@@ -13,14 +13,17 @@ import (
 // DatabasesService is the interface gathering all the methods related to
 // database addon configuration updates
 type DatabasesService interface {
-	DatabaseShow(ctx context.Context, app, addonID string) (Database, error)
-	DatabaseEnableFeature(ctx context.Context, app, addonID, feature string) (DatabaseEnableFeatureResponse, error)
-	DatabaseDisableFeature(ctx context.Context, app, addonID, feature string) (DatabaseDisableFeatureResponse, error)
-	DatabaseUpdatePeriodicBackupsConfig(ctx context.Context, app, addonID string, params DatabaseUpdatePeriodicBackupsConfigParams) (Database, error)
-	DatabaseUpdateMaintenanceWindow(ctx context.Context, app, addonID string, params MaintenanceWindowParams) (Database, error)
-	DatabaseListMaintenance(ctx context.Context, app, addonID string, paginationReq pagination.Request) ([]*Maintenance, pagination.Meta, error)
-	DatabaseShowMaintenance(ctx context.Context, app, addonID, maintenanceID string) (Maintenance, error)
+	DatabaseShow(ctx context.Context, addonID string) (Database, error)
+	DatabaseEnableFeature(ctx context.Context, addonID, feature string) (DatabaseEnableFeatureResponse, error)
+	DatabaseDisableFeature(ctx context.Context, addonID, feature string) (DatabaseDisableFeatureResponse, error)
+	DatabaseUpdatePeriodicBackupsConfig(ctx context.Context, addonID string, params DatabaseUpdatePeriodicBackupsConfigParams) (Database, error)
+	DatabaseUpdateMaintenanceWindow(ctx context.Context, addonID string, params MaintenanceWindowParams) (Database, error)
+	DatabaseListMaintenance(ctx context.Context, addonID string, paginationReq pagination.Request) ([]*Maintenance, pagination.Meta, error)
+	DatabaseShowMaintenance(ctx context.Context, addonID, maintenanceID string) (Maintenance, error)
+	DatabaseRestorePITR(ctx context.Context, addonID string, restoreTime time.Time) (string, error)
 }
+
+var _ DatabasesService = (*Client)(nil)
 
 // DatabaseStatus is a string representing the status of a database deployment
 type DatabaseStatus string
@@ -135,9 +138,9 @@ type DatabaseRes struct {
 }
 
 // DatabaseShow returns the Database info of the given app/addonID
-func (c *Client) DatabaseShow(ctx context.Context, app, addonID string) (Database, error) {
+func (c *Client) DatabaseShow(ctx context.Context, addonID string) (Database, error) {
 	var res DatabaseRes
-	err := c.DBAPI(app, addonID).ResourceGet(ctx, databasesResource, addonID, nil, &res)
+	err := c.ScalingoAPI().ResourceGet(ctx, databasesResource, addonID, nil, &res)
 	if err != nil {
 		return Database{}, errors.Wrapf(ctx, err, "get the database")
 	}
@@ -153,9 +156,9 @@ type DatabaseUpdatePeriodicBackupsConfigParams struct {
 
 // DatabaseUpdatePeriodicBackupsConfig updates the configuration of periodic
 // backups for a given database addon
-func (c *Client) DatabaseUpdatePeriodicBackupsConfig(ctx context.Context, app, addonID string, params DatabaseUpdatePeriodicBackupsConfigParams) (Database, error) {
+func (c *Client) DatabaseUpdatePeriodicBackupsConfig(ctx context.Context, addonID string, params DatabaseUpdatePeriodicBackupsConfigParams) (Database, error) {
 	var dbRes DatabaseRes
-	err := c.DBAPI(app, addonID).ResourceUpdate(ctx, databasesResource, addonID, map[string]DatabaseUpdatePeriodicBackupsConfigParams{
+	err := c.ScalingoAPI().ResourceUpdate(ctx, databasesResource, addonID, map[string]DatabaseUpdatePeriodicBackupsConfigParams{
 		"database": params,
 	}, &dbRes)
 	if err != nil {
@@ -178,7 +181,7 @@ const (
 	DatabaseFeatureStatusActivated DatabaseFeatureStatus = "ACTIVATED"
 	// DatabaseFeatureStatusPending is set when the feature is being enabled
 	DatabaseFeatureStatusPending DatabaseFeatureStatus = "PENDING"
-	// DatabaseFeatureStatusFailed is set when the feature failed to get enabeld
+	// DatabaseFeatureStatusFailed is set when the feature failed to get enabled
 	DatabaseFeatureStatusFailed DatabaseFeatureStatus = "FAILED"
 )
 
@@ -190,7 +193,7 @@ type DatabaseEnableFeatureResponse struct {
 }
 
 // DatabaseEnableFeature enable a feature on a given database addon.
-func (c *Client) DatabaseEnableFeature(ctx context.Context, app, addonID, feature string) (DatabaseEnableFeatureResponse, error) {
+func (c *Client) DatabaseEnableFeature(ctx context.Context, addonID, feature string) (DatabaseEnableFeatureResponse, error) {
 	payload := DatabaseEnableFeatureParams{
 		Feature: DatabaseFeature{
 			Name: feature,
@@ -198,7 +201,7 @@ func (c *Client) DatabaseEnableFeature(ctx context.Context, app, addonID, featur
 	}
 
 	res := DatabaseEnableFeatureResponse{}
-	err := c.DBAPI(app, addonID).DoRequest(ctx, &httpclient.APIRequest{
+	err := c.ScalingoAPI().DoRequest(ctx, &httpclient.APIRequest{
 		Method:   http.MethodPost,
 		Endpoint: "/" + databasesResource + "/" + addonID + "/features",
 		Expected: httpclient.Statuses{http.StatusOK},
@@ -218,9 +221,9 @@ type DatabaseDisableFeatureResponse struct {
 }
 
 // DatabaseDisableFeature disables a feature on a given database addon
-func (c *Client) DatabaseDisableFeature(ctx context.Context, app, addonID, feature string) (DatabaseDisableFeatureResponse, error) {
+func (c *Client) DatabaseDisableFeature(ctx context.Context, addonID, feature string) (DatabaseDisableFeatureResponse, error) {
 	res := DatabaseDisableFeatureResponse{}
-	err := c.DBAPI(app, addonID).DoRequest(ctx, &httpclient.APIRequest{
+	err := c.ScalingoAPI().DoRequest(ctx, &httpclient.APIRequest{
 		Method:   http.MethodDelete,
 		Endpoint: "/" + databasesResource + "/" + addonID + "/features",
 		Expected: httpclient.Statuses{http.StatusOK},
@@ -264,12 +267,12 @@ type DatabaseUserResponse struct {
 }
 
 // DatabaseCreateUser creates an user to the given database addon
-func (c *Client) DatabaseCreateUser(ctx context.Context, app, addonID string, user DatabaseCreateUserParam) (DatabaseUser, error) {
+func (c *Client) DatabaseCreateUser(ctx context.Context, addonID string, user DatabaseCreateUserParam) (DatabaseUser, error) {
 	res := DatabaseUserResponse{}
 	payload := databaseCreateUserPayload{
 		DatabaseUser: user,
 	}
-	err := c.DBAPI(app, addonID).SubresourceAdd(ctx, databasesResource, addonID, usersResource, payload, &res)
+	err := c.ScalingoAPI().SubresourceAdd(ctx, databasesResource, addonID, usersResource, payload, &res)
 	if err != nil {
 		return res.DatabaseUser, errors.Wrapf(ctx, err, "create a user on database %s", addonID)
 	}
@@ -287,12 +290,12 @@ type databaseUpdateUserPayload struct {
 }
 
 // DatabaseUpdateUser updates a user to the given database addon
-func (c *Client) DatabaseUpdateUser(ctx context.Context, app, addonID, username string, databaseUserParams DatabaseUpdateUserParam) (DatabaseUser, error) {
+func (c *Client) DatabaseUpdateUser(ctx context.Context, addonID, username string, databaseUserParams DatabaseUpdateUserParam) (DatabaseUser, error) {
 	res := DatabaseUserResponse{}
 	payload := databaseUpdateUserPayload{
 		DatabaseUser: databaseUserParams,
 	}
-	err := c.DBAPI(app, addonID).SubresourceUpdate(ctx, databasesResource, addonID, usersResource, username, payload, &res)
+	err := c.ScalingoAPI().SubresourceUpdate(ctx, databasesResource, addonID, usersResource, username, payload, &res)
 	if err != nil {
 		return res.DatabaseUser, errors.Wrapf(ctx, err, "update a user on database %s", addonID)
 	}
@@ -305,9 +308,9 @@ type DatabaseUsersResponse struct {
 }
 
 // DatabaseListUsers list the users of the given database addon
-func (c *Client) DatabaseListUsers(ctx context.Context, app, addonID string) ([]DatabaseUser, error) {
+func (c *Client) DatabaseListUsers(ctx context.Context, addonID string) ([]DatabaseUser, error) {
 	res := DatabaseUsersResponse{}
-	err := c.DBAPI(app, addonID).SubresourceList(ctx, databasesResource, addonID, usersResource, nil, &res)
+	err := c.ScalingoAPI().SubresourceList(ctx, databasesResource, addonID, usersResource, nil, &res)
 	if err != nil {
 		return res.DatabaseUsers, errors.Wrap(ctx, err, "get database list of users")
 	}
@@ -315,8 +318,8 @@ func (c *Client) DatabaseListUsers(ctx context.Context, app, addonID string) ([]
 }
 
 // DatabaseDeleteUser delete an user from the given database addon
-func (c *Client) DatabaseDeleteUser(ctx context.Context, app, addonID, userName string) error {
-	return c.DBAPI(app, addonID).SubresourceDelete(ctx, databasesResource, addonID, usersResource, userName)
+func (c *Client) DatabaseDeleteUser(ctx context.Context, addonID, userName string) error {
+	return c.ScalingoAPI().SubresourceDelete(ctx, databasesResource, addonID, usersResource, userName)
 }
 
 // DatabaseUserResetPassword resets the password for a user for given database addon
@@ -327,10 +330,37 @@ func (c *Client) DatabaseUserResetPassword(ctx context.Context, app, addonID, us
 		Endpoint: "/" + databasesResource + "/" + addonID + "/" + usersResource + "/" + username + "/reset_password",
 		Expected: httpclient.Statuses{http.StatusOK},
 	}
-	err := c.DBAPI(app, addonID).DoRequest(ctx, req, &res)
+	err := c.ScalingoAPI().DoRequest(ctx, req, &res)
 	if err != nil {
 		return DatabaseUser{}, err
 	}
 
 	return res.DatabaseUser, nil
+}
+
+type databaseRestorePITRPayload struct {
+	RestoreTime time.Time `json:"restore_time"`
+}
+
+// databaseRestorePITRRes is the response body of database PITR restore.
+type databaseRestorePITRRes struct {
+	OperationID string `json:"operation_id"`
+}
+
+// DatabaseRestorePITR asks for a PITR restore of the given addon/database.
+// It returns the linked operation ID.
+func (c *Client) DatabaseRestorePITR(ctx context.Context, addonID string, restoreTime time.Time) (string, error) {
+	var res databaseRestorePITRRes
+	req := &httpclient.APIRequest{
+		Method:   http.MethodPost,
+		Endpoint: "/" + databasesResource + "/" + addonID + "/pitr/restore",
+		Expected: httpclient.Statuses{http.StatusCreated},
+		Params:   databaseRestorePITRPayload{RestoreTime: restoreTime},
+	}
+	err := c.ScalingoAPI().DoRequest(ctx, req, &res)
+	if err != nil {
+		return "", err
+	}
+
+	return res.OperationID, nil
 }

--- a/vendor/github.com/Scalingo/go-scalingo/v11/databases_preview.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/databases_preview.go
@@ -160,7 +160,7 @@ func (c *PreviewClient) populateAPIResponse(ctx context.Context, apiResponse Dat
 	}
 	databaseNG.App = *app
 
-	databaseNG.Database, err = c.parent.DatabaseShow(ctx, apiResponse.Name, addons[0].ID)
+	databaseNG.Database, err = c.parent.DatabaseShow(ctx, addons[0].ID)
 	if err != nil {
 		debug.Printf("Addon has been removed from app: %+v\n", databaseNG.Name)
 	}

--- a/vendor/github.com/Scalingo/go-scalingo/v11/firewall_rules.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/firewall_rules.go
@@ -16,10 +16,10 @@ const (
 )
 
 type FirewallRulesService interface {
-	FirewallRulesCreate(ctx context.Context, appID string, addonID string, params FirewallRuleCreateParams) (FirewallRule, error)
-	FirewallRulesList(ctx context.Context, appID string, addonID string) ([]FirewallRule, error)
-	FirewallRulesDestroy(ctx context.Context, appID string, addonID string, firewallRuleID string) error
-	FirewallRulesGetManagedRanges(ctx context.Context, appID string, addonID string) ([]FirewallManagedRange, error)
+	FirewallRulesCreate(ctx context.Context, addonID string, params FirewallRuleCreateParams) (FirewallRule, error)
+	FirewallRulesList(ctx context.Context, addonID string) ([]FirewallRule, error)
+	FirewallRulesDestroy(ctx context.Context, addonID string, firewallRuleID string) error
+	FirewallRulesGetManagedRanges(ctx context.Context) ([]FirewallManagedRange, error)
 }
 
 type FirewallManagedRange struct {
@@ -57,20 +57,20 @@ type FirewallRulesResponse struct {
 
 var _ FirewallRulesService = (*PreviewClient)(nil)
 
-func (c *PreviewClient) FirewallRulesCreate(ctx context.Context, appID string, addonID string, params FirewallRuleCreateParams) (FirewallRule, error) {
+func (c *PreviewClient) FirewallRulesCreate(ctx context.Context, addonID string, params FirewallRuleCreateParams) (FirewallRule, error) {
 	var res FirewallRuleResponse
 
-	err := c.parent.DBAPI(appID, addonID).SubresourceAdd(ctx, databasesResource, addonID, firewallRulesResource, params, &res)
+	err := c.parent.ScalingoAPI().SubresourceAdd(ctx, databasesResource, addonID, firewallRulesResource, params, &res)
 	if err != nil {
 		return res.FirewallRule, errors.Wrap(ctx, err, "create firewall rule")
 	}
 	return res.FirewallRule, nil
 }
 
-func (c *PreviewClient) FirewallRulesList(ctx context.Context, appID string, addonID string) ([]FirewallRule, error) {
+func (c *PreviewClient) FirewallRulesList(ctx context.Context, addonID string) ([]FirewallRule, error) {
 	var res FirewallRulesResponse
 
-	err := c.parent.DBAPI(appID, addonID).SubresourceList(ctx, databasesResource, addonID, firewallRulesResource, nil, &res)
+	err := c.parent.ScalingoAPI().SubresourceList(ctx, databasesResource, addonID, firewallRulesResource, nil, &res)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, "list firewall rules")
 	}
@@ -78,15 +78,15 @@ func (c *PreviewClient) FirewallRulesList(ctx context.Context, appID string, add
 	return res.FirewallRules, nil
 }
 
-func (c *PreviewClient) FirewallRulesDestroy(ctx context.Context, appID string, addonID string, firewallRuleID string) error {
-	err := c.parent.DBAPI(appID, addonID).SubresourceDelete(ctx, databasesResource, addonID, firewallRulesResource, firewallRuleID)
+func (c *PreviewClient) FirewallRulesDestroy(ctx context.Context, addonID string, firewallRuleID string) error {
+	err := c.parent.ScalingoAPI().SubresourceDelete(ctx, databasesResource, addonID, firewallRulesResource, firewallRuleID)
 	if err != nil {
 		return errors.Wrap(ctx, err, "destroy firewall rule")
 	}
 	return nil
 }
 
-func (c *PreviewClient) FirewallRulesGetManagedRanges(ctx context.Context, appID string, addonID string) ([]FirewallManagedRange, error) {
+func (c *PreviewClient) FirewallRulesGetManagedRanges(ctx context.Context) ([]FirewallManagedRange, error) {
 	var res FirewallManagedRangesResponse
 
 	req := &httpclient.APIRequest{
@@ -94,7 +94,7 @@ func (c *PreviewClient) FirewallRulesGetManagedRanges(ctx context.Context, appID
 		Endpoint: "/firewall/managed_ranges",
 	}
 
-	err := c.parent.DBAPI(appID, addonID).DoRequest(ctx, req, &res)
+	err := c.parent.ScalingoAPI().DoRequest(ctx, req, &res)
 	if err != nil {
 		return nil, errors.Wrap(ctx, err, "get managed ranges")
 	}

--- a/vendor/github.com/Scalingo/go-scalingo/v11/maintenance.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/maintenance.go
@@ -40,9 +40,9 @@ const (
 	MaintenanceStatusDone      MaintenanceStatus = "done"
 )
 
-func (c *Client) DatabaseUpdateMaintenanceWindow(ctx context.Context, app, addonID string, params MaintenanceWindowParams) (Database, error) {
+func (c *Client) DatabaseUpdateMaintenanceWindow(ctx context.Context, addonID string, params MaintenanceWindowParams) (Database, error) {
 	var dbRes DatabaseRes
-	err := c.DBAPI(app, addonID).ResourceUpdate(ctx, "databases", addonID, map[string]any{
+	err := c.ScalingoAPI().ResourceUpdate(ctx, "databases", addonID, map[string]any{
 		"database": map[string]any{
 			"maintenance_window": params,
 		},
@@ -61,18 +61,18 @@ type ListMaintenanceResponse struct {
 	}
 }
 
-func (c *Client) DatabaseListMaintenance(ctx context.Context, app, addonID string, paginationReq pagination.Request) ([]*Maintenance, pagination.Meta, error) {
+func (c *Client) DatabaseListMaintenance(ctx context.Context, addonID string, paginationReq pagination.Request) ([]*Maintenance, pagination.Meta, error) {
 	var maintenanceRes ListMaintenanceResponse
-	err := c.DBAPI(app, addonID).SubresourceList(ctx, databasesResource, addonID, maintenanceResource, paginationReq.ToURLValues(), &maintenanceRes)
+	err := c.ScalingoAPI().SubresourceList(ctx, databasesResource, addonID, maintenanceResource, paginationReq.ToURLValues(), &maintenanceRes)
 	if err != nil {
 		return nil, pagination.Meta{}, errors.Wrapf(ctx, err, "list database '%v' maintenance", addonID)
 	}
 	return maintenanceRes.Maintenance, maintenanceRes.Meta.Pagination, nil
 }
 
-func (c *Client) DatabaseShowMaintenance(ctx context.Context, app, addonID, maintenanceID string) (Maintenance, error) {
+func (c *Client) DatabaseShowMaintenance(ctx context.Context, addonID, maintenanceID string) (Maintenance, error) {
 	var maintenanceRes Maintenance
-	err := c.DBAPI(app, addonID).SubresourceGet(ctx, databasesResource, addonID, maintenanceResource, maintenanceID, nil, &maintenanceRes)
+	err := c.ScalingoAPI().SubresourceGet(ctx, databasesResource, addonID, maintenanceResource, maintenanceID, nil, &maintenanceRes)
 	if err != nil {
 		return maintenanceRes, errors.Wrapf(ctx, err, "get database '%v' maintenance", addonID)
 	}

--- a/vendor/github.com/Scalingo/go-scalingo/v11/mocks_sig.json
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/mocks_sig.json
@@ -10,7 +10,7 @@
   "..ContainerSizesService": "e2 db 25 a1 01 52 dc e9 6f 7b f4 59 68 95 86 b9 5e 39 8a 61",
   "..ContainersService": "ef 14 ae 81 c9 b4 6a 13 48 e8 bf 44 7d b5 b2 a6 4d e5 02 11",
   "..CronTasksService": "9b d9 a3 ca 9f 9a f7 73 cb b1 aa 80 df 90 21 ff 14 92 b4 4d",
-  "..DatabasesService": "7c 84 0b 87 60 d6 b9 c7 3a a9 53 d2 3a 1c b4 e4 46 f1 83 28",
+  "..DatabasesService": "18 b5 24 09 4c 3b 72 3b ea b9 fb b3 2a d3 5c fb 64 d3 c3 7a",
   "..DeploymentsService": "e1 c5 95 e5 0e 4d db 1e ec 9a 83 d8 e5 41 cc 24 ce f6 ea ba",
   "..DomainsService": "b5 19 0f 10 5b f2 48 74 c6 c2 7b 27 7d 3b b8 ff 10 80 b3 6f",
   "..EventsService": "13 7a 12 83 bf 3f 84 49 dc db 64 c3 d5 e8 4a c0 08 8c 78 f6",

--- a/vendor/github.com/Scalingo/go-scalingo/v11/regions.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/regions.go
@@ -27,7 +27,6 @@ type Region struct {
 	SSH         string `json:"ssh"`
 	API         string `json:"api"`
 	Dashboard   string `json:"dashboard"`
-	DatabaseAPI string `json:"database_api"`
 	Default     bool   `json:"default"`
 }
 

--- a/vendor/github.com/Scalingo/go-scalingo/v11/scalingomock/api_mock.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/scalingomock/api_mock.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	io "io"
 	reflect "reflect"
+	time "time"
 
 	scalingo "github.com/Scalingo/go-scalingo/v11"
 	http "github.com/Scalingo/go-scalingo/v11/http"
@@ -55,33 +56,33 @@ func (mr *MockAPIMockRecorder) AddonDestroy(ctx, app, addonID any) *gomock.Call 
 }
 
 // AddonLogsArchives mocks base method.
-func (m *MockAPI) AddonLogsArchives(ctx context.Context, app, addonID string, page int) (*scalingo.LogsArchivesResponse, error) {
+func (m *MockAPI) AddonLogsArchives(ctx context.Context, addonID string, page int) (*scalingo.LogsArchivesResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddonLogsArchives", ctx, app, addonID, page)
+	ret := m.ctrl.Call(m, "AddonLogsArchives", ctx, addonID, page)
 	ret0, _ := ret[0].(*scalingo.LogsArchivesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddonLogsArchives indicates an expected call of AddonLogsArchives.
-func (mr *MockAPIMockRecorder) AddonLogsArchives(ctx, app, addonID, page any) *gomock.Call {
+func (mr *MockAPIMockRecorder) AddonLogsArchives(ctx, addonID, page any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddonLogsArchives", reflect.TypeOf((*MockAPI)(nil).AddonLogsArchives), ctx, app, addonID, page)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddonLogsArchives", reflect.TypeOf((*MockAPI)(nil).AddonLogsArchives), ctx, addonID, page)
 }
 
 // AddonLogsURL mocks base method.
-func (m *MockAPI) AddonLogsURL(ctx context.Context, app, addonID string) (string, error) {
+func (m *MockAPI) AddonLogsURL(ctx context.Context, addonID string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddonLogsURL", ctx, app, addonID)
+	ret := m.ctrl.Call(m, "AddonLogsURL", ctx, addonID)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AddonLogsURL indicates an expected call of AddonLogsURL.
-func (mr *MockAPIMockRecorder) AddonLogsURL(ctx, app, addonID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) AddonLogsURL(ctx, addonID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddonLogsURL", reflect.TypeOf((*MockAPI)(nil).AddonLogsURL), ctx, app, addonID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddonLogsURL", reflect.TypeOf((*MockAPI)(nil).AddonLogsURL), ctx, addonID)
 }
 
 // AddonProviderPlansList mocks base method.
@@ -532,63 +533,63 @@ func (mr *MockAPIMockRecorder) AutoscalersList(ctx, app any) *gomock.Call {
 }
 
 // BackupCreate mocks base method.
-func (m *MockAPI) BackupCreate(ctx context.Context, app, addonID string) (*scalingo.Backup, error) {
+func (m *MockAPI) BackupCreate(ctx context.Context, addonID string) (*scalingo.Backup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BackupCreate", ctx, app, addonID)
+	ret := m.ctrl.Call(m, "BackupCreate", ctx, addonID)
 	ret0, _ := ret[0].(*scalingo.Backup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BackupCreate indicates an expected call of BackupCreate.
-func (mr *MockAPIMockRecorder) BackupCreate(ctx, app, addonID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) BackupCreate(ctx, addonID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupCreate", reflect.TypeOf((*MockAPI)(nil).BackupCreate), ctx, app, addonID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupCreate", reflect.TypeOf((*MockAPI)(nil).BackupCreate), ctx, addonID)
 }
 
 // BackupDownloadURL mocks base method.
-func (m *MockAPI) BackupDownloadURL(ctx context.Context, app, addonID, backupID string) (string, error) {
+func (m *MockAPI) BackupDownloadURL(ctx context.Context, addonID, backupID string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BackupDownloadURL", ctx, app, addonID, backupID)
+	ret := m.ctrl.Call(m, "BackupDownloadURL", ctx, addonID, backupID)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BackupDownloadURL indicates an expected call of BackupDownloadURL.
-func (mr *MockAPIMockRecorder) BackupDownloadURL(ctx, app, addonID, backupID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) BackupDownloadURL(ctx, addonID, backupID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupDownloadURL", reflect.TypeOf((*MockAPI)(nil).BackupDownloadURL), ctx, app, addonID, backupID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupDownloadURL", reflect.TypeOf((*MockAPI)(nil).BackupDownloadURL), ctx, addonID, backupID)
 }
 
 // BackupList mocks base method.
-func (m *MockAPI) BackupList(ctx context.Context, app, addonID string) ([]scalingo.Backup, error) {
+func (m *MockAPI) BackupList(ctx context.Context, addonID string) ([]scalingo.Backup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BackupList", ctx, app, addonID)
+	ret := m.ctrl.Call(m, "BackupList", ctx, addonID)
 	ret0, _ := ret[0].([]scalingo.Backup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BackupList indicates an expected call of BackupList.
-func (mr *MockAPIMockRecorder) BackupList(ctx, app, addonID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) BackupList(ctx, addonID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupList", reflect.TypeOf((*MockAPI)(nil).BackupList), ctx, app, addonID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupList", reflect.TypeOf((*MockAPI)(nil).BackupList), ctx, addonID)
 }
 
 // BackupShow mocks base method.
-func (m *MockAPI) BackupShow(ctx context.Context, app, addonID, backupID string) (*scalingo.Backup, error) {
+func (m *MockAPI) BackupShow(ctx context.Context, backupID string) (*scalingo.Backup, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BackupShow", ctx, app, addonID, backupID)
+	ret := m.ctrl.Call(m, "BackupShow", ctx, backupID)
 	ret0, _ := ret[0].(*scalingo.Backup)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BackupShow indicates an expected call of BackupShow.
-func (mr *MockAPIMockRecorder) BackupShow(ctx, app, addonID, backupID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) BackupShow(ctx, backupID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupShow", reflect.TypeOf((*MockAPI)(nil).BackupShow), ctx, app, addonID, backupID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BackupShow", reflect.TypeOf((*MockAPI)(nil).BackupShow), ctx, backupID)
 }
 
 // CollaboratorAdd mocks base method.
@@ -694,54 +695,40 @@ func (mr *MockAPIMockRecorder) CronTasksGet(ctx, app any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CronTasksGet", reflect.TypeOf((*MockAPI)(nil).CronTasksGet), ctx, app)
 }
 
-// DBAPI mocks base method.
-func (m *MockAPI) DBAPI(app, addon string) http.Client {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DBAPI", app, addon)
-	ret0, _ := ret[0].(http.Client)
-	return ret0
-}
-
-// DBAPI indicates an expected call of DBAPI.
-func (mr *MockAPIMockRecorder) DBAPI(app, addon any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DBAPI", reflect.TypeOf((*MockAPI)(nil).DBAPI), app, addon)
-}
-
 // DatabaseDisableFeature mocks base method.
-func (m *MockAPI) DatabaseDisableFeature(ctx context.Context, app, addonID, feature string) (scalingo.DatabaseDisableFeatureResponse, error) {
+func (m *MockAPI) DatabaseDisableFeature(ctx context.Context, addonID, feature string) (scalingo.DatabaseDisableFeatureResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DatabaseDisableFeature", ctx, app, addonID, feature)
+	ret := m.ctrl.Call(m, "DatabaseDisableFeature", ctx, addonID, feature)
 	ret0, _ := ret[0].(scalingo.DatabaseDisableFeatureResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DatabaseDisableFeature indicates an expected call of DatabaseDisableFeature.
-func (mr *MockAPIMockRecorder) DatabaseDisableFeature(ctx, app, addonID, feature any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DatabaseDisableFeature(ctx, addonID, feature any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseDisableFeature", reflect.TypeOf((*MockAPI)(nil).DatabaseDisableFeature), ctx, app, addonID, feature)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseDisableFeature", reflect.TypeOf((*MockAPI)(nil).DatabaseDisableFeature), ctx, addonID, feature)
 }
 
 // DatabaseEnableFeature mocks base method.
-func (m *MockAPI) DatabaseEnableFeature(ctx context.Context, app, addonID, feature string) (scalingo.DatabaseEnableFeatureResponse, error) {
+func (m *MockAPI) DatabaseEnableFeature(ctx context.Context, addonID, feature string) (scalingo.DatabaseEnableFeatureResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DatabaseEnableFeature", ctx, app, addonID, feature)
+	ret := m.ctrl.Call(m, "DatabaseEnableFeature", ctx, addonID, feature)
 	ret0, _ := ret[0].(scalingo.DatabaseEnableFeatureResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DatabaseEnableFeature indicates an expected call of DatabaseEnableFeature.
-func (mr *MockAPIMockRecorder) DatabaseEnableFeature(ctx, app, addonID, feature any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DatabaseEnableFeature(ctx, addonID, feature any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseEnableFeature", reflect.TypeOf((*MockAPI)(nil).DatabaseEnableFeature), ctx, app, addonID, feature)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseEnableFeature", reflect.TypeOf((*MockAPI)(nil).DatabaseEnableFeature), ctx, addonID, feature)
 }
 
 // DatabaseListMaintenance mocks base method.
-func (m *MockAPI) DatabaseListMaintenance(ctx context.Context, app, addonID string, paginationReq pagination.Request) ([]*scalingo.Maintenance, pagination.Meta, error) {
+func (m *MockAPI) DatabaseListMaintenance(ctx context.Context, addonID string, paginationReq pagination.Request) ([]*scalingo.Maintenance, pagination.Meta, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DatabaseListMaintenance", ctx, app, addonID, paginationReq)
+	ret := m.ctrl.Call(m, "DatabaseListMaintenance", ctx, addonID, paginationReq)
 	ret0, _ := ret[0].([]*scalingo.Maintenance)
 	ret1, _ := ret[1].(pagination.Meta)
 	ret2, _ := ret[2].(error)
@@ -749,69 +736,84 @@ func (m *MockAPI) DatabaseListMaintenance(ctx context.Context, app, addonID stri
 }
 
 // DatabaseListMaintenance indicates an expected call of DatabaseListMaintenance.
-func (mr *MockAPIMockRecorder) DatabaseListMaintenance(ctx, app, addonID, paginationReq any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DatabaseListMaintenance(ctx, addonID, paginationReq any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseListMaintenance", reflect.TypeOf((*MockAPI)(nil).DatabaseListMaintenance), ctx, app, addonID, paginationReq)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseListMaintenance", reflect.TypeOf((*MockAPI)(nil).DatabaseListMaintenance), ctx, addonID, paginationReq)
+}
+
+// DatabaseRestorePITR mocks base method.
+func (m *MockAPI) DatabaseRestorePITR(ctx context.Context, addonID string, restoreTime time.Time) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DatabaseRestorePITR", ctx, addonID, restoreTime)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DatabaseRestorePITR indicates an expected call of DatabaseRestorePITR.
+func (mr *MockAPIMockRecorder) DatabaseRestorePITR(ctx, addonID, restoreTime any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseRestorePITR", reflect.TypeOf((*MockAPI)(nil).DatabaseRestorePITR), ctx, addonID, restoreTime)
 }
 
 // DatabaseShow mocks base method.
-func (m *MockAPI) DatabaseShow(ctx context.Context, app, addonID string) (scalingo.Database, error) {
+func (m *MockAPI) DatabaseShow(ctx context.Context, addonID string) (scalingo.Database, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DatabaseShow", ctx, app, addonID)
+	ret := m.ctrl.Call(m, "DatabaseShow", ctx, addonID)
 	ret0, _ := ret[0].(scalingo.Database)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DatabaseShow indicates an expected call of DatabaseShow.
-func (mr *MockAPIMockRecorder) DatabaseShow(ctx, app, addonID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DatabaseShow(ctx, addonID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseShow", reflect.TypeOf((*MockAPI)(nil).DatabaseShow), ctx, app, addonID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseShow", reflect.TypeOf((*MockAPI)(nil).DatabaseShow), ctx, addonID)
 }
 
 // DatabaseShowMaintenance mocks base method.
-func (m *MockAPI) DatabaseShowMaintenance(ctx context.Context, app, addonID, maintenanceID string) (scalingo.Maintenance, error) {
+func (m *MockAPI) DatabaseShowMaintenance(ctx context.Context, addonID, maintenanceID string) (scalingo.Maintenance, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DatabaseShowMaintenance", ctx, app, addonID, maintenanceID)
+	ret := m.ctrl.Call(m, "DatabaseShowMaintenance", ctx, addonID, maintenanceID)
 	ret0, _ := ret[0].(scalingo.Maintenance)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DatabaseShowMaintenance indicates an expected call of DatabaseShowMaintenance.
-func (mr *MockAPIMockRecorder) DatabaseShowMaintenance(ctx, app, addonID, maintenanceID any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DatabaseShowMaintenance(ctx, addonID, maintenanceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseShowMaintenance", reflect.TypeOf((*MockAPI)(nil).DatabaseShowMaintenance), ctx, app, addonID, maintenanceID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseShowMaintenance", reflect.TypeOf((*MockAPI)(nil).DatabaseShowMaintenance), ctx, addonID, maintenanceID)
 }
 
 // DatabaseUpdateMaintenanceWindow mocks base method.
-func (m *MockAPI) DatabaseUpdateMaintenanceWindow(ctx context.Context, app, addonID string, params scalingo.MaintenanceWindowParams) (scalingo.Database, error) {
+func (m *MockAPI) DatabaseUpdateMaintenanceWindow(ctx context.Context, addonID string, params scalingo.MaintenanceWindowParams) (scalingo.Database, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DatabaseUpdateMaintenanceWindow", ctx, app, addonID, params)
+	ret := m.ctrl.Call(m, "DatabaseUpdateMaintenanceWindow", ctx, addonID, params)
 	ret0, _ := ret[0].(scalingo.Database)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DatabaseUpdateMaintenanceWindow indicates an expected call of DatabaseUpdateMaintenanceWindow.
-func (mr *MockAPIMockRecorder) DatabaseUpdateMaintenanceWindow(ctx, app, addonID, params any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DatabaseUpdateMaintenanceWindow(ctx, addonID, params any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseUpdateMaintenanceWindow", reflect.TypeOf((*MockAPI)(nil).DatabaseUpdateMaintenanceWindow), ctx, app, addonID, params)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseUpdateMaintenanceWindow", reflect.TypeOf((*MockAPI)(nil).DatabaseUpdateMaintenanceWindow), ctx, addonID, params)
 }
 
 // DatabaseUpdatePeriodicBackupsConfig mocks base method.
-func (m *MockAPI) DatabaseUpdatePeriodicBackupsConfig(ctx context.Context, app, addonID string, params scalingo.DatabaseUpdatePeriodicBackupsConfigParams) (scalingo.Database, error) {
+func (m *MockAPI) DatabaseUpdatePeriodicBackupsConfig(ctx context.Context, addonID string, params scalingo.DatabaseUpdatePeriodicBackupsConfigParams) (scalingo.Database, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DatabaseUpdatePeriodicBackupsConfig", ctx, app, addonID, params)
+	ret := m.ctrl.Call(m, "DatabaseUpdatePeriodicBackupsConfig", ctx, addonID, params)
 	ret0, _ := ret[0].(scalingo.Database)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // DatabaseUpdatePeriodicBackupsConfig indicates an expected call of DatabaseUpdatePeriodicBackupsConfig.
-func (mr *MockAPIMockRecorder) DatabaseUpdatePeriodicBackupsConfig(ctx, app, addonID, params any) *gomock.Call {
+func (mr *MockAPIMockRecorder) DatabaseUpdatePeriodicBackupsConfig(ctx, addonID, params any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseUpdatePeriodicBackupsConfig", reflect.TypeOf((*MockAPI)(nil).DatabaseUpdatePeriodicBackupsConfig), ctx, app, addonID, params)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseUpdatePeriodicBackupsConfig", reflect.TypeOf((*MockAPI)(nil).DatabaseUpdatePeriodicBackupsConfig), ctx, addonID, params)
 }
 
 // Deployment mocks base method.

--- a/vendor/github.com/Scalingo/go-scalingo/v11/scalingomock/databasesservice_mock.go
+++ b/vendor/github.com/Scalingo/go-scalingo/v11/scalingomock/databasesservice_mock.go
@@ -7,6 +7,7 @@ package scalingomock
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	scalingo "github.com/Scalingo/go-scalingo/v11"
 	pagination "github.com/Scalingo/go-utils/pagination"
@@ -81,6 +82,21 @@ func (m *MockDatabasesService) DatabaseListMaintenance(ctx context.Context, app,
 func (mr *MockDatabasesServiceMockRecorder) DatabaseListMaintenance(ctx, app, addonID, paginationReq any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseListMaintenance", reflect.TypeOf((*MockDatabasesService)(nil).DatabaseListMaintenance), ctx, app, addonID, paginationReq)
+}
+
+// DatabaseRestorePITR mocks base method.
+func (m *MockDatabasesService) DatabaseRestorePITR(ctx context.Context, app, addonID string, restoreTime time.Time) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DatabaseRestorePITR", ctx, app, addonID, restoreTime)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DatabaseRestorePITR indicates an expected call of DatabaseRestorePITR.
+func (mr *MockDatabasesServiceMockRecorder) DatabaseRestorePITR(ctx, app, addonID, restoreTime any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DatabaseRestorePITR", reflect.TypeOf((*MockDatabasesService)(nil).DatabaseRestorePITR), ctx, app, addonID, restoreTime)
 }
 
 // DatabaseShow mocks base method.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -37,7 +37,7 @@ github.com/ProtonMail/go-crypto/openpgp/packet
 github.com/ProtonMail/go-crypto/openpgp/s2k
 github.com/ProtonMail/go-crypto/openpgp/x25519
 github.com/ProtonMail/go-crypto/openpgp/x448
-# github.com/Scalingo/go-scalingo/v11 v11.1.1
+# github.com/Scalingo/go-scalingo/v11 v11.1.2-0.20260810110303-774d8583f620
 ## explicit; go 1.25.0
 github.com/Scalingo/go-scalingo/v11
 github.com/Scalingo/go-scalingo/v11/billing


### PR DESCRIPTION
The DB API has been deprovisionned and is not required anymore.
This is pending confirmation from UFS [here](https://scalingo.slack.com/archives/C6GE4JP3L/p1786358646421339).

Based on [this](https://github.com/Scalingo/go-scalingo/pull/515) go-scalingo PR.

- [X] Add a changelog entry in the section "To Be Released" of CHANGELOG.md
- [ ] Update go-scalingo to the new released version

Fix #1247 .